### PR TITLE
Fix Health thresholds text boxes width.

### DIFF
--- a/src/main/resources/util/health.jelly
+++ b/src/main/resources/util/health.jelly
@@ -15,14 +15,14 @@
           <td style="vertical-align: middle;">
             <img src="${rootURL}/images/16x16/health-80plus.gif" alt="100%" title="${%description.healthy}" /> ${%threshold.100.percent}
           </td>
-          <td>
+          <td width="40">
             <f:textbox name="healthy" value="${instance.healthy}" />
           </td>
           <td width="20"/>
           <td style="vertical-align: middle;">
             <img src="${rootURL}/images/16x16/health-00to19.gif" alt="0%" title="${%description.unhealthy}" /> ${%threshold.0.percent}
           </td>
-          <td>
+          <td width="40">
             <f:textbox name="unHealthy" value="${instance.unHealthy}" />
           </td>
         </tr>


### PR DESCRIPTION
IE's Quriks mode renders Health thresholds text boxes too thin for users to input values.
