### PR TITLE
Fix NPE on job saving when previous Builds are absent (baseline == null)

### DIFF
--- a/src/main/java/hudson/plugins/analysis/core/BuildHistory.java
+++ b/src/main/java/hudson/plugins/analysis/core/BuildHistory.java
@@ -77,11 +77,14 @@ public class BuildHistory {
      *         such build exists
      */
     private ResultAction<? extends BuildResult> getReferenceAction() {
-        for (AbstractBuild<?, ?> build = baseline.getPreviousBuild(); build != null; build = build.getPreviousBuild()) {
-            if (hasValidResult(build)) {
-                ResultAction<? extends BuildResult> action = build.getAction(type);
-                if (action != null && action.isSuccessful()) {
-                    return action;
+        if (null != baseline) {
+            for (AbstractBuild<?, ?> build = baseline.getPreviousBuild(); build != null;
+                 build = build.getPreviousBuild()) {
+                if (hasValidResult(build)) {
+                    ResultAction<? extends BuildResult> action = build.getAction(type);
+                    if (action != null && action.isSuccessful()) {
+                        return action;
+                    }
                 }
             }
         }
@@ -155,11 +158,14 @@ public class BuildHistory {
      */
     @CheckForNull
     private ResultAction<? extends BuildResult> getPreviousAction() {
-        for (AbstractBuild<?, ?> build = baseline.getPreviousBuild(); build != null; build = build.getPreviousBuild()) {
-            if (hasValidResult(build)) {
-                ResultAction<? extends BuildResult> action = build.getAction(type);
-                if (action != null) {
-                    return action;
+        if (null != baseline) {
+            for (AbstractBuild<?, ?> build = baseline.getPreviousBuild(); build != null;
+                 build = build.getPreviousBuild()) {
+                if (hasValidResult(build)) {
+                    ResultAction<? extends BuildResult> action = build.getAction(type);
+                    if (action != null) {
+                        return action;
+                    }
                 }
             }
         }
@@ -175,7 +181,7 @@ public class BuildHistory {
      *             if there is no previous result
      */
     public ResultAction<? extends BuildResult> getBaseline() {
-        return baseline.getAction(type);
+        return null != baseline ? baseline.getAction(type) : null;
     }
 
     /**

--- a/src/main/java/hudson/plugins/analysis/graph/GraphConfigurationView.java
+++ b/src/main/java/hudson/plugins/analysis/graph/GraphConfigurationView.java
@@ -60,7 +60,7 @@ public abstract class GraphConfigurationView implements ModelObject {
         this.pluginName = pluginName;
 
         this.buildHistory = buildHistory;
-        healthDescriptor = buildHistory.getBaseline().getHealthDescriptor();
+        healthDescriptor = null != buildHistory.getBaseline() ? buildHistory.getBaseline().getHealthDescriptor() : null;
     }
 
     /**
@@ -252,7 +252,7 @@ public abstract class GraphConfigurationView implements ModelObject {
      * @return <code>true</code>, if the health graph is available
      */
     public boolean isHealthGraphAvailable() {
-        return healthDescriptor.isEnabled();
+        return null != healthDescriptor && healthDescriptor.isEnabled();
     }
 
     /**


### PR DESCRIPTION
I have faced with NPE while using the latest version of this plugin with PMD and Checkstyle plugins. When I tried to save job configuration and there were no previous builds for current job, I get the following stacktrace: 
WARNING: Caught exception evaluating: from.canShowEnableTrendLink(request). Reason: java.lang.NullPointerException
java.lang.NullPointerException
    at hudson.plugins.analysis.core.BuildHistory.getBaseline(BuildHistory.java:178)
    at hudson.plugins.analysis.graph.GraphConfigurationView.<init>(GraphConfigurationView.java:63)
    at hudson.plugins.analysis.graph.UserGraphConfigurationView.<init>(UserGraphConfigurationView.java:36)
    at hudson.plugins.analysis.core.AbstractProjectAction.createUserConfiguration(AbstractProjectAction.java:219)
Proposed request solves them. Tested on the latest version of analysis-core, PMD, Checkstyle
