### PR TITLE
Fixed broken compatibility with Hudson (java.lang.NoSuchMethodError:net.sf.json.JSONObject.put(Ljava/lang/String;Ljava/lang/Object;))

### DIFF
--- a/src/main/java/hudson/plugins/analysis/core/PluginDescriptor.java
+++ b/src/main/java/hudson/plugins/analysis/core/PluginDescriptor.java
@@ -45,9 +45,9 @@ public abstract class PluginDescriptor extends BuildStepDescriptor<Publisher> {
             JSONObject output = JSONObject.fromObject(hierarchical);
             output.remove(NEW_SECTION_KEY);
             for (Object key : newSection.keySet()) {
-                output.put((String)key, newSection.get(key));
+                output.element((String)key, newSection.get(key));
             }
-            output.put(NEW_SECTION_KEY, true);
+            output.element(NEW_SECTION_KEY, true);
 
             return output;
         }


### PR DESCRIPTION
Hudson uses the latest version of json-lib instead of patched 2.1-rev6 version.This error appears because  of changed by KK signature of the method in the patched library: 
public Object put( String key, Object value ) 
instead of public Object put( Object key, Object value ) in original library.
This workaround allows plugin to work in both Jenkins and Hudson. 
Could you please review and apply it?
Thank you.
