### PR TITLE
Reduce runtime memory footprint by eliminating in-memory LineRange.

### DIFF
--- a/src/main/java/hudson/plugins/analysis/util/model/AbstractAnnotation.java
+++ b/src/main/java/hudson/plugins/analysis/util/model/AbstractAnnotation.java
@@ -7,6 +7,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+import com.google.common.collect.ImmutableList;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.export.Exported;
@@ -41,8 +42,11 @@ public abstract class AbstractAnnotation implements FileAnnotation, Serializable
     private Priority priority;
     /** Unique key of this annotation. */
     private final long key;
-    /** The ordered list of line ranges that show the origin of the annotation in the associated file. */
-    private final List<LineRange> lineRanges;
+    /**
+     * The ordered list of line ranges that show the origin of the annotation in the associated file.
+     * To save memory consumption, this can be {@link ImmutableList}, in which case updates requires a new copy.
+     */
+    private LineRangeList lineRanges;
     /** Primary line number of this warning, i.e., the start line of the first line range. */
     private final int primaryLineNumber;
     /** The filename of the class that contains this annotation. */
@@ -91,7 +95,7 @@ public abstract class AbstractAnnotation implements FileAnnotation, Serializable
 
         key = currentKey++;
 
-        lineRanges = new ArrayList<LineRange>();
+        lineRanges = new LineRangeList();
         lineRanges.add(new LineRange(start, end));
         primaryLineNumber = start;
 
@@ -133,7 +137,7 @@ public abstract class AbstractAnnotation implements FileAnnotation, Serializable
         message = copy.getMessage();
         priority = copy.getPriority();
         primaryLineNumber = copy.getPrimaryLineNumber();
-        lineRanges = new ArrayList<LineRange>(copy.getLineRanges());
+        lineRanges = new LineRangeList(copy.getLineRanges());
 
         contextHashCode = copy.getContextHashCode();
 

--- a/src/main/java/hudson/plugins/analysis/util/model/LineRangeList.java
+++ b/src/main/java/hudson/plugins/analysis/util/model/LineRangeList.java
@@ -1,0 +1,360 @@
+package hudson.plugins.analysis.util.model;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.Converter;
+import com.thoughtworks.xstream.converters.UnmarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import hudson.util.RobustCollectionConverter;
+
+import java.util.AbstractList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.ListIterator;
+
+/**
+ * {@link List} of {@link LineRange} that stores values more efficiently at runtime.
+ *
+ * <p>
+ * This class thinks of {@link LineRange} as two integers (start and end-start), hence a list of {@link LineRange}
+ * becomes a list of integers. The class then stores those integers in {@code byte[]}.
+ * Each number is packed to UTF-8 like variable length format. To store a long value N, we first
+ * split into 7 bit chunk, and store each 7 bit chunk as a byte, in the little endian order.
+ * The last byte gets its 8th bit set to indicate that that's the last byte.
+ * Thus in this format, 0x0 gets stored as 0x80, 0x1234 gets stored as {0x34,0xA4(0x24|0x80)}.
+ *
+ * <p>
+ * This variable length mode stores data most efficiently, since most line numbers are small. Access characteristic
+ * gets close to that of {@link LinkedList}, since we can only traverse this packed byte[] from the start or
+ * from the end.
+ *
+ * @author Kohsuke Kawaguchi
+ */
+public class LineRangeList extends AbstractList<LineRange> {
+    /**
+     * Encoded bits.
+     */
+    private byte[] data;
+    /**
+     * Number of bytes in {@link #data} that's already used. This is not {@link List#size()}.
+     */
+    private int len;
+
+    public LineRangeList() {
+        this(16);
+    }
+
+    public LineRangeList(int capacity) {
+        data = new byte[capacity];
+        len = 0;
+    }
+
+    public LineRangeList(Collection<LineRange> copy) {
+        data = new byte[copy.size()*4]; // guess
+        for (LineRange lr : copy)
+            add(lr);
+    }
+
+    private class Cursor implements ListIterator<LineRange> {
+        int pos = 0;
+
+        private Cursor(int pos) {
+            this.pos = pos;
+        }
+
+        private Cursor() {
+        }
+
+        /**
+         * Does the opposite of {@link #read()} and skips back one int.
+         */
+        private void prev() {
+            if (pos==0)
+                throw new IllegalArgumentException();
+            do {
+                pos--;
+            } while (pos>0 && (data[pos-1]&0x80)==0);
+        }
+
+        /**
+         * Reads the {@link LineRange} object the cursor is pointing at.
+         */
+        public LineRange next() {
+            int s = read();
+            int d = read();
+            return new LineRange(s,s+d);
+        }
+
+        public LineRange previous() {
+            prev();
+            prev();
+            return copy().next();
+        }
+
+        /**
+         * Removes the last returned value.
+         */
+        public void remove() {
+            prev();
+            prev();
+            delete();
+        }
+
+        public boolean hasNext() {
+            return pos<len;
+        }
+
+        public boolean hasPrevious() {
+            return pos>0;
+        }
+
+        /**
+         * Reads the current variable-length encoded int value under the cursor, and moves the cursor ahead.
+         */
+        private int read() {
+            if (len<=pos)
+                throw new IndexOutOfBoundsException();
+
+            int i = 0;
+            int v = 0;
+            do {
+                v += (data[pos]&0x7F)<<((i++)*7);
+            } while((data[pos++]&0x80)==0);
+            return v;
+        }
+
+        private void write(int i) {
+            boolean last;
+            do {
+                last = i<0x80;
+                data[pos++] = (byte)((i&0x7F)|(last?0x80:0));
+                i /= 0x80;
+            } while (!last);
+        }
+
+        private void write(LineRange r) {
+            write(r.getStart());
+            write(r.getEnd()-r.getStart());
+        }
+
+        /**
+         * Reads the current value at the cursor and compares it.
+         */
+        public boolean compare(LineRange lr) {
+            int s = read();
+            int d = read();
+            return lr.getStart()==s && lr.getEnd()==s+d;
+        }
+
+        /**
+         * Skips forward and gets the pointer to N-th element.
+         */
+        private Cursor skip(int n) {
+            for ( ; n>0; n--) {
+                read();
+                read();
+            }
+            return this;
+        }
+
+        /**
+         * Counts the # of elements from the current cursor position to the end.
+         */
+        private int count() {
+            int n = 0;
+            while (pos<len) {
+                read();
+                read();
+                n++;
+            }
+            return n;
+        }
+
+        public int nextIndex() {
+            throw new UnsupportedOperationException();
+        }
+
+        public int previousIndex() {
+            throw new UnsupportedOperationException();
+        }
+
+        public Cursor copy() {
+            return new Cursor(pos);
+        }
+
+        private void adjust(int diff) {
+            ensure(len+diff);
+            if (diff>0) // make diff bytes room at 'pos'
+                System.arraycopy(data,pos, data,pos+diff, len-pos);
+            else // delete -diff bytes from 'pos'
+                System.arraycopy(data,pos-diff, data,pos, len-pos+diff);
+            len += diff;
+        }
+
+        /**
+         * Rewrites the value at the current cursor position.
+         */
+        public LineRange _set(LineRange v) {
+            Cursor c = copy();
+            LineRange old = c.next();
+            int oldSize = c.pos-pos;
+            int newSize = sizeOf(v);
+            adjust(newSize - oldSize);
+            write(v);
+            return old;
+        }
+
+        public void set(LineRange v) {
+            _set(v);
+        }
+
+
+        /**
+         * Inserts the value at the current cursor position.
+         */
+        public void add(LineRange v) {
+            int newSize = sizeOf(v);
+            adjust(newSize);
+            write(v);
+        }
+
+        /**
+         * Removes the current value at the cursor position.
+         */
+        public LineRange delete() {
+            Cursor c = copy();
+            LineRange old = c.next();
+            adjust(pos-c.pos);
+            return old;
+        }
+
+        private int sizeOf(LineRange v) {
+            return sizeOf(v.getStart())+sizeOf(v.getEnd()-v.getStart());
+        }
+
+        /**
+         * Computes the number of bytes that the value 'i' would occupy in its encoded form.
+         */
+        private int sizeOf(int i) {
+            int n = 0;
+            do {
+                i /= 0x80;
+                n++;
+            } while (i>0);
+            return n;
+        }
+    }
+
+    /**
+     * Makes sure that the buffer has capability to store N bytes.
+     */
+    private void ensure(int n) {
+        if (data.length<n) {
+            byte[] buf = new byte[Math.max(n,data.length*2)];
+            System.arraycopy(data,0,buf,0,len);
+            data = buf;
+        }
+    }
+
+    @Override
+    public boolean contains(Object o) {
+        if (o instanceof LineRange) {
+            LineRange lr = (LineRange)o;
+
+            for (Cursor c=new Cursor(); c.hasNext(); ) {
+                if (c.compare(lr))
+                    return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public LineRange get(int index) {
+        return new Cursor().skip(index).next();
+    }
+
+    @Override
+    public int size() {
+        return new Cursor().count();
+    }
+
+    @Override
+    public LineRange set(int index, LineRange element) {
+        return new Cursor().skip(index)._set(element);
+    }
+
+    @Override
+    public void add(int index, LineRange element) {
+        new Cursor().skip(index).add(element);
+    }
+
+    @Override
+    public LineRange remove(int index) {
+        return new Cursor().skip(index).delete();
+    }
+
+    @Override
+    public boolean add(LineRange lr) {
+        new Cursor(len).add(lr);
+        return true;
+    }
+
+    @Override
+    public void clear() {
+        len = 0;
+    }
+
+    @Override
+    public Iterator<LineRange> iterator() {
+        return new Cursor();
+    }
+
+    @Override
+    public ListIterator<LineRange> listIterator() {
+        return new Cursor();
+    }
+
+    @Override
+    public ListIterator<LineRange> listIterator(int index) {
+        return new Cursor().skip(index);
+    }
+
+    /**
+     * Minimizes the memory waste by throwing away excess capacity.
+     */
+    public void trim() {
+        if (len!=data.length) {
+            byte[] small = new byte[len];
+            System.arraycopy(data,0,small,0,len);
+            data = small;
+        }
+    }
+
+    /**
+     * {@link Converter} implementation for XStream.
+     */
+    public static final class ConverterImpl extends RobustCollectionConverter {
+        public ConverterImpl(XStream xs) {
+            super(xs);
+        }
+
+        @Override
+        public boolean canConvert(Class type) {
+            return type==LineRangeList.class;
+        }
+
+        @Override
+        protected void populateCollection(HierarchicalStreamReader reader, UnmarshallingContext context, Collection collection) {
+            super.populateCollection(reader, context, collection);
+            ((LineRangeList)collection).trim();
+        }
+
+        @Override
+        protected Object createCollection(Class type) {
+            return new LineRangeList();
+        }
+    }
+
+}

--- a/src/test/java/hudson/plugins/analysis/util/model/LineRangeListTest.java
+++ b/src/test/java/hudson/plugins/analysis/util/model/LineRangeListTest.java
@@ -1,0 +1,79 @@
+package hudson.plugins.analysis.util.model;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Kohsuke Kawaguchi
+ */
+public class LineRangeListTest {
+
+    @Test
+    public void bigValues() {
+        LineRangeList r = new LineRangeList();
+        LineRange v = new LineRange(1350,Integer.MAX_VALUE);
+        r.add(v);
+        assertTrue(r.contains(v));
+    }
+
+    @Test
+    public void boundary() {
+        LineRangeList r = new LineRangeList();
+        LineRange v = new LineRange(128,129);
+        r.add(v);
+        assertTrue(r.contains(v));
+    }
+
+    @Test
+    public void basicCRUD() {
+        LineRangeList r = new LineRangeList();
+        LineRange v = new LineRange(1, 2);
+        r.add(v);
+        assertEquals(r.get(0), v);
+        assertNotSame(r.get(0),v);
+        assertEquals(1, r.size());
+
+        LineRange v2 = new LineRange(3, 4);
+        assertEquals(v,r.set(0, v2));
+        assertEquals(r.get(0), v2);
+        assertNotSame(r.get(0), v2);
+        assertEquals(1, r.size());
+
+        assertEquals(v2,r.remove(0));
+        assertEquals(0,r.size());
+    }
+
+    /**
+     * Tests the internal buffer resize operation.
+     */
+    @Test
+    public void resize() {
+        LineRangeList r = new LineRangeList();
+        for (int i=0; i<100; i++) {
+            r.add(new LineRange(i*2,i*2+1));
+        }
+        r.trim();
+        assertEquals(100, r.size());
+
+        for (int i=0; i<100; i++) {
+            assertEquals(new LineRange(i*2,i*2+1), r.get(i));
+        }
+
+        assertEquals(100,r.size());
+    }
+
+    @Test
+    public void contains() {
+        LineRangeList r = new LineRangeList();
+        r.add(new LineRange(0,1));
+        r.add(new LineRange(2,3));
+        r.add(new LineRange(4,5));
+
+        r.remove(new LineRange(4, 5));
+
+        assertTrue(r.contains(new LineRange(0,1)));
+        assertTrue(r.contains(new LineRange(2,3)));
+        assertFalse(r.contains(new LineRange(4, 5)));
+    }
+}


### PR DESCRIPTION
The way `List<LineRange>` is stored in memory has a lot of overhead.

This change makes the in-memory representation a lot more compact by using variable-length encoding like UTF-8. `List<LineRange>` can be thought of as a sequence of integers, and these integers get packed into a single byte array.

This provides access characteristics like `LinkedList` (i.e., `get(i)` is expensive), and mutation characteristics like `ArrayList` (i.e., `add(i,o)` is expensive), but otherwise fully satisfies `List` contract.

On my test data set, this is about 2.6MB saving (down from 15.0MB, about 17%).
