### PR TITLE
Apply the memory footprint improvement when parsing reports from tools.

### DIFF
--- a/src/main/java/hudson/plugins/analysis/util/TreeStringBuilder.java
+++ b/src/main/java/hudson/plugins/analysis/util/TreeStringBuilder.java
@@ -125,7 +125,16 @@ public class TreeStringBuilder {
      * Interns a string.
      */
     public TreeString intern(final String s) {
+        if (s==null)    return null;
         return root.intern(s).node;
+    }
+
+    /**
+     * Interns a {@link TreeString} created elsewhere.
+     */
+    public TreeString intern(final TreeString s) {
+        if (s==null)    return null;
+        return root.intern(s.toString()).node;
     }
 
     /**


### PR DESCRIPTION
The series of changes leading up to this change so far only affects when loading `FileAnnotation[]` via XStream, so it won't help when we are parsing output from tools.

This change plugs that last hole, by applying data reuse at the end of `AbstractAnnotationParser.parse()`.

I think reasonable people can argue about who's implementation details this processing is. I'm not particularly attached to this implementation, so any adjustments are welcome as long as it achieves the goal of having this dedup process kick in for newly parsed reports.

For example, doing it here means it doesn't kick in when someone calls parse(InputStream), but this has an advantages of not needing to update every subtypes, and letting the caller of AnnotationParser does this has its own set of downsides.
