### PR TITLE
Added code to avoid NPE

### DIFF
--- a/src/main/java/hudson/plugins/analysis/core/AbstractProjectAction.java
+++ b/src/main/java/hudson/plugins/analysis/core/AbstractProjectAction.java
@@ -337,8 +337,11 @@ public abstract class AbstractProjectAction<T extends ResultAction<?>> implement
      */
     public String getIconFileName() {
         ResultAction<?> lastAction = getLastAction();
-        if (lastAction != null && lastAction.getResult().hasAnnotations()) {
-            return iconUrl;
+        if (lastAction != null) {
+            BuildResult result = lastAction.getResult();
+            if (result != null && result.hasAnnotations()) {
+                return iconUrl;
+            }
         }
         return null;
     }

--- a/src/main/java/hudson/plugins/analysis/core/HealthAwareReporter.java
+++ b/src/main/java/hudson/plugins/analysis/core/HealthAwareReporter.java
@@ -160,7 +160,7 @@ public abstract class HealthAwareReporter<T extends BuildResult> extends MavenRe
         super();
         this.healthy = healthy;
         this.unHealthy = unHealthy;
-        this.thresholdLimit = thresholdLimit;
+        this.thresholdLimit = thresholdLimit != null ? thresholdLimit : DEFAULT_PRIORITY_THRESHOLD_LIMIT;
         this.canRunOnFailed = canRunOnFailed;
         this.dontComputeNew = !canComputeNew;
         this.pluginName = "[" + pluginName + "] ";


### PR DESCRIPTION
I have fixed two NullPointerExceptions.

The first one was in     hudson.plugins.analysis.core.AbstractProjectAction.getIconFileName(AbstractProjectAction.java:340)

The second one was:
    java.lang.NullPointerException: Name is null
        at java.lang.Enum.valueOf(Enum.java:195)
        at hudson.plugins.analysis.util.model.Priority.valueOf(Priority.java:1)
        at hudson.plugins.analysis.core.HealthAwareReporter.getMinimumPriority(HealthAwareReporter.java:592)
        at hudson.plugins.analysis.core.AbstractHealthDescriptor.<init>(AbstractHealthDescriptor.java:36)
        at hudson.plugins.analysis.core.NullHealthDescriptor.<init>(NullHealthDescriptor.java:71)
        at hudson.plugins.analysis.core.HealthAwareReporter.registerResults(HealthAwareReporter.java:339)
        at hudson.plugins.analysis.core.HealthAwareReporter.access$2(HealthAwareReporter.java:335)
        at hudson.plugins.analysis.core.HealthAwareReporter$1.call(HealthAwareReporter.java:325)
        at hudson.plugins.analysis.core.HealthAwareReporter$1.call(HealthAwareReporter.java:1)

Both exceptions occured in a Maven-based build which is a bit unusual since it only runs Checkstyle.
