### PR TITLE
Fix for JENKINS-15037

### DIFF
--- a/src/main/java/hudson/plugins/analysis/core/HealthAwarePublisher.java
+++ b/src/main/java/hudson/plugins/analysis/core/HealthAwarePublisher.java
@@ -27,6 +27,101 @@ import hudson.tasks.BuildStep;
  */
 // CHECKSTYLE:OFF
 public abstract class HealthAwarePublisher extends HealthAwareRecorder {
+
+    private final boolean useStableBuildAsReference;
+
+    /**
+     * Creates a new instance of {@link HealthAwarePublisher}.
+     *
+     * @param healthy
+     *            Report health as 100% when the number of open tasks is less
+     *            than this value
+     * @param unHealthy
+     *            Report health as 0% when the number of open tasks is greater
+     *            than this value
+     * @param thresholdLimit
+     *            determines which warning priorities should be considered when
+     *            evaluating the build stability and health
+     * @param defaultEncoding
+     *            the default encoding to be used when reading and parsing files
+     * @param useDeltaValues
+     *            determines whether the absolute annotations delta or the
+     *            actual annotations set difference should be used to evaluate
+     *            the build stability
+     * @param unstableTotalAll
+     *            annotation threshold
+     * @param unstableTotalHigh
+     *            annotation threshold
+     * @param unstableTotalNormal
+     *            annotation threshold
+     * @param unstableTotalLow
+     *            annotation threshold
+     * @param unstableNewAll
+     *            annotation threshold
+     * @param unstableNewHigh
+     *            annotation threshold
+     * @param unstableNewNormal
+     *            annotation threshold
+     * @param unstableNewLow
+     *            annotation threshold
+     * @param failedTotalAll
+     *            annotation threshold
+     * @param failedTotalHigh
+     *            annotation threshold
+     * @param failedTotalNormal
+     *            annotation threshold
+     * @param failedTotalLow
+     *            annotation threshold
+     * @param failedNewAll
+     *            annotation threshold
+     * @param failedNewHigh
+     *            annotation threshold
+     * @param failedNewNormal
+     *            annotation threshold
+     * @param failedNewLow
+     *            annotation threshold
+     * @param canRunOnFailed
+     *            determines whether the plug-in can run for failed builds, too
+     * @param useStableBuildAsReference
+     *            determines whether only stable builds should be used as
+     *            reference builds or not
+     * @param shouldDetectModules
+     *            determines whether module names should be derived from Maven
+     *            POM or Ant build files
+     * @param canComputeNew
+     *            determines whether new warnings should be computed (with
+     *            respect to baseline)
+     * @param canResolveRelativePaths
+     *            determines whether relative paths in warnings should be
+     *            resolved using a time expensive operation that scans the whole
+     *            workspace for matching files.
+     * @param pluginName
+     *            the name of the plug-in
+     * @since 1.47
+     */
+    @SuppressWarnings("PMD")
+    public HealthAwarePublisher(final String healthy, final String unHealthy,
+            final String thresholdLimit, final String defaultEncoding,
+            final boolean useDeltaValues, final String unstableTotalAll,
+            final String unstableTotalHigh, final String unstableTotalNormal,
+            final String unstableTotalLow, final String unstableNewAll,
+            final String unstableNewHigh, final String unstableNewNormal,
+            final String unstableNewLow, final String failedTotalAll, final String failedTotalHigh,
+            final String failedTotalNormal, final String failedTotalLow, final String failedNewAll,
+            final String failedNewHigh, final String failedNewNormal, final String failedNewLow,
+            final boolean canRunOnFailed, final boolean useStableBuildAsReference,
+            final boolean shouldDetectModules, final boolean canComputeNew,
+            final boolean canResolveRelativePaths, final String pluginName) {
+        super(healthy, unHealthy, thresholdLimit, defaultEncoding, useDeltaValues,
+                unstableTotalAll, unstableTotalHigh, unstableTotalNormal, unstableTotalLow,
+                unstableNewAll, unstableNewHigh, unstableNewNormal, unstableNewLow, failedTotalAll,
+                failedTotalHigh, failedTotalNormal, failedTotalLow, failedNewAll, failedNewHigh,
+                failedNewNormal, failedNewLow, canRunOnFailed,
+                shouldDetectModules, canComputeNew, canResolveRelativePaths, pluginName);
+        this.useStableBuildAsReference = useStableBuildAsReference;
+
+    }
+
     /**
      * Creates a new instance of {@link HealthAwarePublisher}.
      *
@@ -105,11 +200,11 @@ public abstract class HealthAwarePublisher extends HealthAwareRecorder {
             final boolean canRunOnFailed, final boolean shouldDetectModules,
             final boolean canComputeNew, final boolean canResolveRelativePaths,
             final String pluginName) {
-        super(healthy, unHealthy, thresholdLimit, defaultEncoding, useDeltaValues,
+        this(healthy, unHealthy, thresholdLimit, defaultEncoding, useDeltaValues,
                 unstableTotalAll, unstableTotalHigh, unstableTotalNormal, unstableTotalLow,
                 unstableNewAll, unstableNewHigh, unstableNewNormal, unstableNewLow, failedTotalAll,
                 failedTotalHigh, failedTotalNormal, failedTotalLow, failedNewAll, failedNewHigh,
-                failedNewNormal, failedNewLow, canRunOnFailed, shouldDetectModules, canComputeNew,
+                failedNewNormal, failedNewLow, canRunOnFailed, false, shouldDetectModules, canComputeNew,
                 canResolveRelativePaths, pluginName);
     }
 
@@ -280,6 +375,14 @@ public abstract class HealthAwarePublisher extends HealthAwareRecorder {
     protected abstract BuildResult perform(AbstractBuild<?, ?> build, PluginLogger logger)
             throws InterruptedException, IOException;
 
+    /**
+     * Determines whether only stable builds should be used as reference builds or not
+     * @return <code>true</code> if only stable builds should be used
+     */
+    public boolean getUseStableBuildAsReference() {
+        return useStableBuildAsReference;
+    }
+
     // CHECKSTYLE:OFF
     @Deprecated
     @SuppressWarnings({"PMD.ExcessiveParameterList","javadoc"})
@@ -328,5 +431,6 @@ public abstract class HealthAwarePublisher extends HealthAwareRecorder {
             final boolean useDeltaValues, final boolean canRunOnFailed, final String pluginName) {
         super(threshold, newThreshold, failureThreshold, newFailureThreshold, healthy, unHealthy,
                 thresholdLimit, defaultEncoding, useDeltaValues, canRunOnFailed, pluginName);
+        useStableBuildAsReference = false;
     }
 }

--- a/src/main/java/hudson/plugins/analysis/core/HealthAwareReporter.java
+++ b/src/main/java/hudson/plugins/analysis/core/HealthAwareReporter.java
@@ -92,6 +92,110 @@ public abstract class HealthAwareReporter<T extends BuildResult> extends MavenRe
      * @since 1.34
      */
     private final boolean dontComputeNew;
+    /**
+     * Determines whether only stable builds should be used as reference builds or not
+     *
+     * @since 1.47
+     */
+    private final boolean useStableBuildAsReference;
+
+    /**
+     * Creates a new instance of <code>HealthReportingMavenReporter</code>.
+     *
+     * @param healthy
+     *            Report health as 100% when the number of warnings is less than
+     *            this value
+     * @param unHealthy
+     *            Report health as 0% when the number of warnings is greater
+     *            than this value
+     * @param thresholdLimit
+     *            determines which warning priorities should be considered when
+     *            evaluating the build stability and health
+     * @param useDeltaValues
+     *            determines whether the absolute annotations delta or the
+     *            actual annotations set difference should be used to evaluate
+     *            the build stability
+     * @param unstableTotalAll
+     *            annotation threshold
+     * @param unstableTotalHigh
+     *            annotation threshold
+     * @param unstableTotalNormal
+     *            annotation threshold
+     * @param unstableTotalLow
+     *            annotation threshold
+     * @param unstableNewAll
+     *            annotation threshold
+     * @param unstableNewHigh
+     *            annotation threshold
+     * @param unstableNewNormal
+     *            annotation threshold
+     * @param unstableNewLow
+     *            annotation threshold
+     * @param failedTotalAll
+     *            annotation threshold
+     * @param failedTotalHigh
+     *            annotation threshold
+     * @param failedTotalNormal
+     *            annotation threshold
+     * @param failedTotalLow
+     *            annotation threshold
+     * @param failedNewAll
+     *            annotation threshold
+     * @param failedNewHigh
+     *            annotation threshold
+     * @param failedNewNormal
+     *            annotation threshold
+     * @param failedNewLow
+     *            annotation threshold
+     * @param canRunOnFailed
+     *            determines whether the plug-in can run for failed builds, too
+     * @param useStableBuildAsReference
+     *            determines whether only stable builds should be used as reference builds or not
+     * @param canComputeNew
+     *            determines whether new warnings should be computed (with respect to baseline)
+     * @param pluginName
+     *            the name of the plug-in
+     */
+    // CHECKSTYLE:OFF
+    @SuppressWarnings("PMD.ExcessiveParameterList")
+    public HealthAwareReporter(final String healthy, final String unHealthy, final String thresholdLimit, final boolean useDeltaValues,
+            final String unstableTotalAll, final String unstableTotalHigh, final String unstableTotalNormal, final String unstableTotalLow,
+            final String unstableNewAll, final String unstableNewHigh, final String unstableNewNormal, final String unstableNewLow,
+            final String failedTotalAll, final String failedTotalHigh, final String failedTotalNormal, final String failedTotalLow,
+            final String failedNewAll, final String failedNewHigh, final String failedNewNormal, final String failedNewLow,
+            final boolean canRunOnFailed, final boolean useStableBuildAsReference, final boolean canComputeNew,
+            final String pluginName) {
+        super();
+        this.healthy = healthy;
+        this.unHealthy = unHealthy;
+        this.thresholdLimit = thresholdLimit;
+        this.canRunOnFailed = canRunOnFailed;
+        this.useStableBuildAsReference = useStableBuildAsReference;
+        this.dontComputeNew = !canComputeNew;
+        this.pluginName = "[" + pluginName + "] ";
+
+        this.useDeltaValues = useDeltaValues;
+
+        thresholds.unstableTotalAll = unstableTotalAll;
+        thresholds.unstableTotalHigh = unstableTotalHigh;
+        thresholds.unstableTotalNormal = unstableTotalNormal;
+        thresholds.unstableTotalLow = unstableTotalLow;
+        thresholds.unstableNewAll = unstableNewAll;
+        thresholds.unstableNewHigh = unstableNewHigh;
+        thresholds.unstableNewNormal = unstableNewNormal;
+        thresholds.unstableNewLow = unstableNewLow;
+        thresholds.failedTotalAll = failedTotalAll;
+        thresholds.failedTotalHigh = failedTotalHigh;
+        thresholds.failedTotalNormal = failedTotalNormal;
+        thresholds.failedTotalLow = failedTotalLow;
+        thresholds.failedNewAll = failedNewAll;
+        thresholds.failedNewHigh = failedNewHigh;
+        thresholds.failedNewNormal = failedNewNormal;
+        thresholds.failedNewLow = failedNewLow;
+
+        System.setProperty("org.apache.commons.logging.Log", "org.apache.commons.logging.impl.Jdk14Logger");
+    }
+    // CHECKSTYLE:ON
 
     /**
      * Creates a new instance of <code>HealthReportingMavenReporter</code>.
@@ -150,6 +254,7 @@ public abstract class HealthAwareReporter<T extends BuildResult> extends MavenRe
      */
     // CHECKSTYLE:OFF
     @SuppressWarnings("PMD.ExcessiveParameterList")
+    @Deprecated
     public HealthAwareReporter(final String healthy, final String unHealthy, final String thresholdLimit, final boolean useDeltaValues,
             final String unstableTotalAll, final String unstableTotalHigh, final String unstableTotalNormal, final String unstableTotalLow,
             final String unstableNewAll, final String unstableNewHigh, final String unstableNewNormal, final String unstableNewLow,
@@ -157,34 +262,13 @@ public abstract class HealthAwareReporter<T extends BuildResult> extends MavenRe
             final String failedNewAll, final String failedNewHigh, final String failedNewNormal, final String failedNewLow,
             final boolean canRunOnFailed, final boolean canComputeNew,
             final String pluginName) {
-        super();
-        this.healthy = healthy;
-        this.unHealthy = unHealthy;
-        this.thresholdLimit = thresholdLimit;
-        this.canRunOnFailed = canRunOnFailed;
-        this.dontComputeNew = !canComputeNew;
-        this.pluginName = "[" + pluginName + "] ";
-
-        this.useDeltaValues = useDeltaValues;
-
-        thresholds.unstableTotalAll = unstableTotalAll;
-        thresholds.unstableTotalHigh = unstableTotalHigh;
-        thresholds.unstableTotalNormal = unstableTotalNormal;
-        thresholds.unstableTotalLow = unstableTotalLow;
-        thresholds.unstableNewAll = unstableNewAll;
-        thresholds.unstableNewHigh = unstableNewHigh;
-        thresholds.unstableNewNormal = unstableNewNormal;
-        thresholds.unstableNewLow = unstableNewLow;
-        thresholds.failedTotalAll = failedTotalAll;
-        thresholds.failedTotalHigh = failedTotalHigh;
-        thresholds.failedTotalNormal = failedTotalNormal;
-        thresholds.failedTotalLow = failedTotalLow;
-        thresholds.failedNewAll = failedNewAll;
-        thresholds.failedNewHigh = failedNewHigh;
-        thresholds.failedNewNormal = failedNewNormal;
-        thresholds.failedNewLow = failedNewLow;
-
-        System.setProperty("org.apache.commons.logging.Log", "org.apache.commons.logging.impl.Jdk14Logger");
+        this(healthy, unHealthy, thresholdLimit, useDeltaValues,
+                unstableTotalAll, unstableTotalHigh, unstableTotalNormal, unstableTotalLow,
+                unstableNewAll, unstableNewHigh, unstableNewNormal, unstableNewLow,
+                failedTotalAll, failedTotalHigh, failedTotalNormal, failedTotalLow,
+                failedNewAll, failedNewHigh, failedNewNormal, failedNewLow,
+                canRunOnFailed, false, canComputeNew,
+                pluginName);
     }
     // CHECKSTYLE:ON
 
@@ -239,6 +323,15 @@ public abstract class HealthAwareReporter<T extends BuildResult> extends MavenRe
      */
     public boolean getUseDeltaValues() {
         return useDeltaValues;
+    }
+
+    /**
+     * Determines whether only stable builds should be used as reference builds or not
+     *
+     * @return <code>true</code> if only stable builds should be used
+     */
+    public boolean getUseStableBuildAsReference() {
+        return useStableBuildAsReference;
     }
 
     /** {@inheritDoc} */

--- a/src/main/resources/util/thresholds.jelly
+++ b/src/main/resources/util/thresholds.jelly
@@ -1,8 +1,8 @@
 <?jelly escape-by-default='true'?>
-<!-- 
-  Section header 
-  
-  <%@attribute name="id" required="true" %> 
+<!--
+  Section header
+
+  <%@attribute name="id" required="true" %>
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
@@ -133,6 +133,10 @@
         <f:entry title="${%Use delta for new warnings}"
           description="${%description.useDeltaValues}">
           <f:checkbox name="useDeltaValues" checked="${instance.useDeltaValues}" />
+        </f:entry>
+        <f:entry title="${%Only use stable builds as reference}"
+          description="${%description.onlyUseStableBuildsAsReference}">
+          <f:checkbox name="useStableBuildAsReference" checked="${instance.useStableBuildAsReference}" />
         </f:entry>
       </f:optionalBlock>
     </table>

--- a/src/main/resources/util/thresholds.properties
+++ b/src/main/resources/util/thresholds.properties
@@ -6,13 +6,13 @@ description.useDeltaValues=If set then the number of new warnings is calculated 
                    minor changes in a warning (refactoring of variable of method names, etc.)
 description.status.total=If the number of total warnings is greater than one of these thresholds then a build is \
                    considered as unstable or failed, respectively. I.e., a value of 0 means that the build status is
-                   changed if there is at least one warning found. \ 
-                   Leave this field empty if the state of the build should not depend on the number of warnings.  
+                   changed if there is at least one warning found. \
+                   Leave this field empty if the state of the build should not depend on the number of warnings.
 title.status.total=Status thresholds (Totals)
 description.status.total=If the number of new warnings is greater than one of these thresholds then a build is \
                    considered as unstable or failed, respectively. I.e., a value of 0 means that the build status is
-                   changed if there is at least one new warning found. \ 
-                   Leave this field empty if the state of the build should not depend on the number of warnings.  
+                   changed if there is at least one new warning found. \
+                   Leave this field empty if the state of the build should not depend on the number of warnings.
 description.status.new=If the specified number of new warnings exceeds one of these thresholds then a build is \
                    considered as unstable or failed, respectively.
 title.status.new=Status thresholds (New warnings)
@@ -25,5 +25,7 @@ description.unstableNew=If the number of new warnings exceeds a threshold then a
                    considered as unstable.
 description.failedNew=If the number of new warnings exceeds a threshold then a build is \
                    considered as failed.
-                   
+description.onlyUseStableBuildsAsReference=The number of new warnings will be calculated based on the last \
+                   stable build, allowing reverts of unstable builds where the number of warnings was decreased.
+
 compute.new.title=Compute new warnings (based on reference build)


### PR DESCRIPTION
Fix for JENKINS-15037 - Option to consider only stable builds when calculating new warnings

Please consider my comments below prior to accepting.
