### PR TITLE
Removed the background from the space behind the priority graph

### DIFF
--- a/src/main/resources/result/priority-graph.jelly
+++ b/src/main/resources/result/priority-graph.jelly
@@ -23,7 +23,7 @@
         <td class="priority-low" style="width:${low / max * 100}%">
         </td>
       </j:if>
-      <td style="background:white;width:${ (max - high - normal - low) / max * 100}%">
+      <td style="width:${ (max - high - normal - low) / max * 100}%">
       </td>
     </tr>
   </table>


### PR DESCRIPTION
The column needs to exist, but there's no reason for it to have a background. Especially when using custom CSS, these white bars are clearly noticeable.
