### PR TITLE
[JENKINS-25977] Add workflow compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ target
 .idea
 .DS_Store
 /work
+.project
+.classpath

--- a/pom.xml
+++ b/pom.xml
@@ -4,8 +4,7 @@
   <parent>
     <groupId>org.jvnet.hudson.plugins</groupId>
     <artifactId>analysis-pom</artifactId>
-    <version>1.62-SNAPSHOT</version>
-    <relativePath>../analysis-pom/pom.xml</relativePath>
+    <version>1.62</version>
   </parent>
 
   <artifactId>analysis-core</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jvnet.hudson.plugins</groupId>
     <artifactId>analysis-pom</artifactId>
-    <version>1.59</version>
+    <version>1.62-SNAPSHOT</version>
     <relativePath>../analysis-pom/pom.xml</relativePath>
   </parent>
 
@@ -42,6 +42,11 @@
       <groupId>xerces</groupId>
       <artifactId>xercesImpl</artifactId>
       <version>2.11.0</version>
+    </dependency>
+    <dependency><!-- 2.4 is required. Avoid transitive import derived issues -->
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.4</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
       <version>2.4</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,12 @@
       <version>2.4</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>com.infradna.tool</groupId>
+      <artifactId>bridge-method-annotation</artifactId>
+      <version>1.14</version>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
 
   <scm>
@@ -86,7 +92,7 @@
       <plugin>
         <groupId>com.infradna.tool</groupId>
         <artifactId>bridge-method-injector</artifactId>
-        <version>1.2</version>
+        <version>1.14</version>
         <executions>
           <execution>
             <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jvnet.hudson.plugins</groupId>
     <artifactId>analysis-pom</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
   </parent>
 
   <artifactId>analysis-core</artifactId>

--- a/src/main/java/hudson/plugins/analysis/core/AbstractResultAction.java
+++ b/src/main/java/hudson/plugins/analysis/core/AbstractResultAction.java
@@ -128,9 +128,8 @@ public abstract class AbstractResultAction<T extends BuildResult> implements Sta
      * 
      * @see {@link WithBridgeMethods}
      */
-    @Restricted(NoExternalUse.class)
     @Deprecated
-    public final Object getAbstractBuild(Run owner, Class targetClass) {
+    private final Object getAbstractBuild(Run owner, Class targetClass) {
       return owner instanceof AbstractBuild ? (AbstractBuild) owner : null;
     }
 

--- a/src/main/java/hudson/plugins/analysis/core/AbstractResultAction.java
+++ b/src/main/java/hudson/plugins/analysis/core/AbstractResultAction.java
@@ -10,12 +10,14 @@ import org.kohsuke.stapler.export.ExportedBean;
 
 import edu.umd.cs.findbugs.annotations.SuppressWarnings;
 import jenkins.model.Jenkins;
-
 import hudson.maven.MavenBuild;
 import hudson.maven.MavenModule;
+
 import hudson.model.AbstractBuild;
+import hudson.model.Run;
 import hudson.model.HealthReport;
 import hudson.model.HealthReportingAction;
+
 import hudson.plugins.analysis.Messages;
 import hudson.plugins.analysis.util.ToolTipProvider;
 
@@ -35,7 +37,7 @@ import hudson.plugins.analysis.util.ToolTipProvider;
 @ExportedBean
 public abstract class AbstractResultAction<T extends BuildResult> implements StaplerProxy, HealthReportingAction, ToolTipProvider, ResultAction<T> {
     /** The associated build of this action. */
-    private final AbstractBuild<?, ?> owner;
+    private final Run<?, ?> owner;
     /** Parameters for the health report. */
     private final AbstractHealthDescriptor healthDescriptor;
     /** The actual result of this action. */
@@ -51,7 +53,7 @@ public abstract class AbstractResultAction<T extends BuildResult> implements Sta
      * @param result
      *            the result of the action
      */
-    public AbstractResultAction(final AbstractBuild<?, ?> owner, final AbstractHealthDescriptor healthDescriptor, final T result) {
+    public AbstractResultAction(final Run<?, ?> owner, final AbstractHealthDescriptor healthDescriptor, final T result) {
         this.owner = owner;
         this.result = result;
         this.healthDescriptor = healthDescriptor;
@@ -104,12 +106,12 @@ public abstract class AbstractResultAction<T extends BuildResult> implements Sta
      *
      * @return the associated build of this action
      */
-    public final AbstractBuild<?, ?> getOwner() {
+    public final Run<?, ?> getOwner() {
         return owner;
     }
 
     @Override
-    public final AbstractBuild<?, ?> getBuild() {
+    public final Run<?, ?> getBuild() {
         return owner;
     }
 

--- a/src/main/java/hudson/plugins/analysis/core/AbstractResultAction.java
+++ b/src/main/java/hudson/plugins/analysis/core/AbstractResultAction.java
@@ -288,6 +288,24 @@ public abstract class AbstractResultAction<T extends BuildResult> implements Sta
         this.healthDescriptor = healthDescriptor;
     }
 
+    /**
+     * Creates a new instance of <code>AbstractResultAction</code>.
+     *
+     * @param owner
+     *            the associated build of this action
+     * @param healthDescriptor
+     *            health descriptor
+     * @param result
+     *            the result of the action
+     * @deprecated use {@link #AbstractResultAction(Run, AbstractHealthDescriptor, BuildResult)} instead
+     */
+    @Deprecated
+    public AbstractResultAction(final AbstractBuild<?, ?> owner, final AbstractHealthDescriptor healthDescriptor, final T result) {
+        this.owner = owner;
+        this.result = result;
+        this.healthDescriptor = healthDescriptor;
+    }
+
     /** Backward compatibility. @deprecated */
     @Deprecated
     @java.lang.SuppressWarnings("PMD")

--- a/src/main/java/hudson/plugins/analysis/core/AbstractResultAction.java
+++ b/src/main/java/hudson/plugins/analysis/core/AbstractResultAction.java
@@ -6,8 +6,6 @@ import java.util.Map;
 import jenkins.model.Jenkins;
 
 import org.apache.commons.lang.StringUtils;
-import org.kohsuke.accmod.Restricted;
-import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.StaplerProxy;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
@@ -129,7 +127,7 @@ public abstract class AbstractResultAction<T extends BuildResult> implements Sta
      * @see {@link WithBridgeMethods}
      */
     @Deprecated
-    private final Object getAbstractBuild(Run owner, Class targetClass) {
+    private Object getAbstractBuild(final Run owner, final Class targetClass) {
       return owner instanceof AbstractBuild ? (AbstractBuild) owner : null;
     }
 

--- a/src/main/java/hudson/plugins/analysis/core/AbstractResultAction.java
+++ b/src/main/java/hudson/plugins/analysis/core/AbstractResultAction.java
@@ -3,20 +3,25 @@ package hudson.plugins.analysis.core;
 import java.util.List;
 import java.util.Map;
 
+import jenkins.model.Jenkins;
+
 import org.apache.commons.lang.StringUtils;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.StaplerProxy;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
 
+import com.infradna.tool.bridge_method_injector.WithBridgeMethods;
+
 import edu.umd.cs.findbugs.annotations.SuppressWarnings;
-import jenkins.model.Jenkins;
 import hudson.maven.MavenBuild;
 import hudson.maven.MavenModule;
 
-import hudson.model.AbstractBuild;
-import hudson.model.Run;
 import hudson.model.HealthReport;
 import hudson.model.HealthReportingAction;
+import hudson.model.AbstractBuild;
+import hudson.model.Run;
 
 import hudson.plugins.analysis.Messages;
 import hudson.plugins.analysis.util.ToolTipProvider;
@@ -106,13 +111,28 @@ public abstract class AbstractResultAction<T extends BuildResult> implements Sta
      *
      * @return the associated build of this action
      */
+    @WithBridgeMethods(value=AbstractBuild.class, adapterMethod="getAbstractBuild")
     public final Run<?, ?> getOwner() {
         return owner;
     }
 
     @Override
+    @WithBridgeMethods(value=AbstractBuild.class, adapterMethod="getAbstractBuild")
+    @Deprecated
     public final Run<?, ?> getBuild() {
         return owner;
+    }
+
+    /**
+     * Added for backward compatibility. It generates <pre>AbstractBuild getOwner()</pre> bytecode during the build
+     * process, so old implementations can use that signature.
+     * 
+     * @see {@link WithBridgeMethods}
+     */
+    @Restricted(NoExternalUse.class)
+    @Deprecated
+    public final Object getAbstractBuild(Run owner, Class targetClass) {
+      return owner instanceof AbstractBuild ? (AbstractBuild) owner : null;
     }
 
     @Override

--- a/src/main/java/hudson/plugins/analysis/core/AbstractResultAction.java
+++ b/src/main/java/hudson/plugins/analysis/core/AbstractResultAction.java
@@ -118,7 +118,6 @@ public abstract class AbstractResultAction<T extends BuildResult> implements Sta
 
     @Override
     @WithBridgeMethods(value=AbstractBuild.class, adapterMethod="getAbstractBuild")
-    @Deprecated
     public final Run<?, ?> getBuild() {
         return owner;
     }

--- a/src/main/java/hudson/plugins/analysis/core/AnnotationsClassifier.java
+++ b/src/main/java/hudson/plugins/analysis/core/AnnotationsClassifier.java
@@ -3,9 +3,7 @@ package hudson.plugins.analysis.core;
 import java.io.File;
 import java.io.IOException;
 
-import org.jenkinsci.remoting.RoleChecker;
-
-import hudson.FilePath.FileCallable;
+import jenkins.MasterToSlaveFileCallable;
 
 import hudson.plugins.analysis.util.ContextHashCode;
 import hudson.plugins.analysis.util.model.FileAnnotation;
@@ -18,7 +16,7 @@ import hudson.remoting.VirtualChannel;
  *
  * @author Ulli Hafner
  */
-public class AnnotationsClassifier implements FileCallable<ParserResult> {
+public class AnnotationsClassifier extends MasterToSlaveFileCallable<ParserResult> {
     /** Generated ID. */
     private static final long serialVersionUID = 5152042155205600031L;
     /** All annotations. */
@@ -52,10 +50,5 @@ public class AnnotationsClassifier implements FileCallable<ParserResult> {
             }
         }
         return result;
-    }
-
-    @Override
-    public void checkRoles(RoleChecker checker) throws SecurityException {
-        // TODO required in 1.580 (do we need to implement something here?)
     }
 }

--- a/src/main/java/hudson/plugins/analysis/core/AnnotationsClassifier.java
+++ b/src/main/java/hudson/plugins/analysis/core/AnnotationsClassifier.java
@@ -3,6 +3,8 @@ package hudson.plugins.analysis.core;
 import java.io.File;
 import java.io.IOException;
 
+import org.jenkinsci.remoting.RoleChecker;
+
 import hudson.FilePath.FileCallable;
 
 import hudson.plugins.analysis.util.ContextHashCode;
@@ -50,5 +52,10 @@ public class AnnotationsClassifier implements FileCallable<ParserResult> {
             }
         }
         return result;
+    }
+
+    @Override
+    public void checkRoles(RoleChecker checker) throws SecurityException {
+        // TODO required in 1.580 (do we need to implement something here?)
     }
 }

--- a/src/main/java/hudson/plugins/analysis/core/BuildHistory.java
+++ b/src/main/java/hudson/plugins/analysis/core/BuildHistory.java
@@ -198,9 +198,10 @@ public class BuildHistory {
      */
     @Deprecated
     private Object getReferenceAbstractBuild(Run run, Class targetClass) {
-        if (run != null && run instanceof AbstractBuild) {
+        if (run instanceof AbstractBuild) {
             return (AbstractBuild) run;
-        } else {
+        }
+        else {
             return null;
         }
     }

--- a/src/main/java/hudson/plugins/analysis/core/BuildHistory.java
+++ b/src/main/java/hudson/plugins/analysis/core/BuildHistory.java
@@ -51,7 +51,7 @@ public class BuildHistory {
      * @param useStableBuildAsReference
      *            determines whether only stable builds should be used as
      *            reference builds or not
-     * @since 1.66
+     * @since 1.73
      */
     public BuildHistory(final Run<?, ?> baseline,
             final Class<? extends ResultAction<? extends BuildResult>> type,
@@ -174,7 +174,7 @@ public class BuildHistory {
      * build.
      *
      * @return the reference build
-     * @since 1.20
+     * @since 1.73
      * @see #hasReferenceBuild()
      */
     @CheckForNull
@@ -197,13 +197,8 @@ public class BuildHistory {
      * @see {@link WithBridgeMethods}
      */
     @Deprecated
-    private Object getReferenceAbstractBuild(Run run, Class targetClass) {
-        if (run instanceof AbstractBuild) {
-            return (AbstractBuild) run;
-        }
-        else {
-            return null;
-        }
+    private Object getReferenceAbstractBuild(final Run run, final Class targetClass) {
+        return run instanceof AbstractBuild ? (AbstractBuild) run : null;
     }
 
     private boolean hasValidResult(final Run<?, ?> build) {

--- a/src/main/java/hudson/plugins/analysis/core/BuildHistory.java
+++ b/src/main/java/hudson/plugins/analysis/core/BuildHistory.java
@@ -333,7 +333,7 @@ public class BuildHistory {
      * @deprecated use {@link #BuildHistory(AbstractBuild, Class, boolean, boolean)}
      */
     @Deprecated
-    public BuildHistory(final Run<?, ?> baseline, final Class<? extends ResultAction<? extends BuildResult>> type,
+    public BuildHistory(final AbstractBuild<?, ?> baseline, final Class<? extends ResultAction<? extends BuildResult>> type,
             final boolean useStableBuildAsReference) {
         this(baseline, type, false, useStableBuildAsReference);
     }

--- a/src/main/java/hudson/plugins/analysis/core/BuildHistory.java
+++ b/src/main/java/hudson/plugins/analysis/core/BuildHistory.java
@@ -152,6 +152,10 @@ public class BuildHistory {
     /**
      * Returns the result action of the specified build that should be used to
      * compute the history.
+     *
+     * @param build
+     *            the build
+     * @return the result action
      */
     @CheckForNull
     public ResultAction<? extends BuildResult> getResultAction(@Nonnull final Run<?, ?> build) {

--- a/src/main/java/hudson/plugins/analysis/core/BuildHistory.java
+++ b/src/main/java/hudson/plugins/analysis/core/BuildHistory.java
@@ -2,6 +2,8 @@ package hudson.plugins.analysis.core;
 
 import javax.annotation.CheckForNull;
 
+import com.infradna.tool.bridge_method_injector.WithBridgeMethods;
+
 import java.util.Calendar;
 import java.util.Collection;
 import java.util.Collections;
@@ -149,10 +151,6 @@ public class BuildHistory {
     /**
      * Returns the result action of the specified build that should be used to
      * compute the history.
-     *
-     * @param build
-     *            the build
-     * @return the result action
      */
     @CheckForNull
     public ResultAction<? extends BuildResult> getResultAction(final Run<?, ?> build) {
@@ -179,6 +177,7 @@ public class BuildHistory {
      * @see #hasReferenceBuild()
      */
     @CheckForNull
+    @WithBridgeMethods(value=AbstractBuild.class, adapterMethod="getReferenceAbstractBuild")
     public Run<?, ?> getReferenceBuild() {
         ResultAction<? extends BuildResult> action = getReferenceAction();
         if (action != null) {
@@ -188,6 +187,21 @@ public class BuildHistory {
             }
         }
         return null;
+    }
+
+    /**
+     * Added for backward compatibility. It generates <pre>AbstractBuild getReferenceBuild()</pre> bytecode during the build
+     * process, so old implementations can use that signature.
+     * 
+     * @see {@link WithBridgeMethods}
+     */
+    @Deprecated
+    private Object getReferenceAbstractBuild(Run run, Class targetClass) {
+        if (run != null && run instanceof AbstractBuild) {
+            return (AbstractBuild) run;
+        } else {
+            return null;
+        }
     }
 
     private boolean hasValidResult(final Run<?, ?> build) {
@@ -374,10 +388,22 @@ public class BuildHistory {
             final Class<? extends ResultAction<? extends BuildResult>> type,
             final boolean usePreviousBuildAsReference,
             final boolean useStableBuildAsReference) {
-        this.baseline = baseline;
-        this.type = type;
-        this.usePreviousBuildAsReference = usePreviousBuildAsReference;
-        this.useStableBuildAsReference = useStableBuildAsReference;
+        this((Run<?, ?>) baseline, type, usePreviousBuildAsReference, useStableBuildAsReference);
+    }
+
+    /**
+     * Returns the result action of the specified build that should be used to
+     * compute the history.
+     *
+     * @param build
+     *            the build
+     * @return the result action
+     * @deprecated use {@link #getResultAction(Run)} instead
+     */
+    @CheckForNull
+    @Deprecated
+    public ResultAction<? extends BuildResult> getResultAction(final AbstractBuild<?, ?> build) {
+        return getResultAction((Run<?, ?>) build);
     }
 }
 

--- a/src/main/java/hudson/plugins/analysis/core/BuildHistory.java
+++ b/src/main/java/hudson/plugins/analysis/core/BuildHistory.java
@@ -351,5 +351,33 @@ public class BuildHistory {
     public BuildHistory(final AbstractBuild<?, ?> baseline, final Class<? extends ResultAction<? extends BuildResult>> type) {
         this(baseline, type, false);
     }
+
+    /**
+     * Creates a new instance of {@link BuildHistory}.
+     *
+     * @param baseline
+     *            the build to start the history from
+     * @param type
+     *            type of the action that contains the build results
+     * @param usePreviousBuildAsReference
+     *            determines whether the previous build should always be used
+     *            as the reference build
+     * @param useStableBuildAsReference
+     *            determines whether only stable builds should be used as
+     *            reference builds or not
+     * @since 1.66
+     * 
+     * @deprecated use {@link #BuildHistory(Run, Class, boolean, boolean)}
+     */
+    @Deprecated
+    public BuildHistory(final AbstractBuild<?, ?> baseline,
+            final Class<? extends ResultAction<? extends BuildResult>> type,
+            final boolean usePreviousBuildAsReference,
+            final boolean useStableBuildAsReference) {
+        this.baseline = baseline;
+        this.type = type;
+        this.usePreviousBuildAsReference = usePreviousBuildAsReference;
+        this.useStableBuildAsReference = useStableBuildAsReference;
+    }
 }
 

--- a/src/main/java/hudson/plugins/analysis/core/BuildHistory.java
+++ b/src/main/java/hudson/plugins/analysis/core/BuildHistory.java
@@ -1,6 +1,7 @@
 package hudson.plugins.analysis.core;
 
 import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
 
 import com.infradna.tool.bridge_method_injector.WithBridgeMethods;
 
@@ -153,7 +154,7 @@ public class BuildHistory {
      * compute the history.
      */
     @CheckForNull
-    public ResultAction<? extends BuildResult> getResultAction(final Run<?, ?> build) {
+    public ResultAction<? extends BuildResult> getResultAction(@Nonnull final Run<?, ?> build) {
         return build.getAction(type);
     }
 

--- a/src/main/java/hudson/plugins/analysis/core/BuildHistory.java
+++ b/src/main/java/hudson/plugins/analysis/core/BuildHistory.java
@@ -1,6 +1,7 @@
 package hudson.plugins.analysis.core;
 
 import javax.annotation.CheckForNull;
+
 import java.util.Calendar;
 import java.util.Collection;
 import java.util.Collections;
@@ -8,7 +9,9 @@ import java.util.NoSuchElementException;
 import java.util.Set;
 
 import hudson.model.AbstractBuild;
+import hudson.model.Run;
 import hudson.model.Result;
+
 import hudson.plugins.analysis.util.model.AnnotationContainer;
 import hudson.plugins.analysis.util.model.DefaultAnnotationContainer;
 import hudson.plugins.analysis.util.model.FileAnnotation;
@@ -21,7 +24,7 @@ import hudson.plugins.analysis.util.model.FileAnnotation;
  */
 public class BuildHistory {
     /** The build to start the history from. */
-    private final AbstractBuild<?, ?> baseline;
+    private final Run<?, ?> baseline;
     /** Type of the action that contains the build results. */
     private final Class<? extends ResultAction<? extends BuildResult>> type;
     /** Determines whether only stable builds should be used as reference builds or not. */
@@ -47,7 +50,7 @@ public class BuildHistory {
      *            reference builds or not
      * @since 1.66
      */
-    public BuildHistory(final AbstractBuild<?, ?> baseline,
+    public BuildHistory(final Run<?, ?> baseline,
             final Class<? extends ResultAction<? extends BuildResult>> type,
             final boolean usePreviousBuildAsReference,
             final boolean useStableBuildAsReference) {
@@ -130,7 +133,7 @@ public class BuildHistory {
     }
 
     private ResultAction<? extends BuildResult> getAction(final boolean isStatusRelevant, final boolean mustBeStable) {
-        for (AbstractBuild<?, ?> build = baseline.getPreviousBuild(); build != null; build = build.getPreviousBuild()) {
+        for (Run<?, ?> build = baseline.getPreviousBuild(); build != null; build = build.getPreviousBuild()) {
             ResultAction<? extends BuildResult> action = getResultAction(build);
             if (hasValidResult(build, mustBeStable, action) && isSuccessfulAction(action, isStatusRelevant)) {
                 return action;
@@ -152,7 +155,7 @@ public class BuildHistory {
      * @return the result action
      */
     @CheckForNull
-    public ResultAction<? extends BuildResult> getResultAction(final AbstractBuild<?, ?> build) {
+    public ResultAction<? extends BuildResult> getResultAction(final Run<?, ?> build) {
         return build.getAction(type);
     }
 
@@ -176,10 +179,10 @@ public class BuildHistory {
      * @see #hasReferenceBuild()
      */
     @CheckForNull
-    public AbstractBuild<?, ?> getReferenceBuild() {
+    public Run<?, ?> getReferenceBuild() {
         ResultAction<? extends BuildResult> action = getReferenceAction();
         if (action != null) {
-            AbstractBuild<?, ?> build = action.getBuild();
+            Run<?, ?> build = action.getBuild();
             if (hasValidResult(build)) {
                 return build;
             }
@@ -187,11 +190,11 @@ public class BuildHistory {
         return null;
     }
 
-    private boolean hasValidResult(final AbstractBuild<?, ?> build) {
+    private boolean hasValidResult(final Run<?, ?> build) {
         return hasValidResult(build, false, null);
     }
 
-    private boolean hasValidResult(final AbstractBuild<?, ?> build, final boolean mustBeStable, @CheckForNull final ResultAction<? extends BuildResult> action) {
+    private boolean hasValidResult(final Run<?, ?> build, final boolean mustBeStable, @CheckForNull final ResultAction<? extends BuildResult> action) {
         Result result = build.getResult();
 
         if (result == null) {
@@ -330,7 +333,7 @@ public class BuildHistory {
      * @deprecated use {@link #BuildHistory(AbstractBuild, Class, boolean, boolean)}
      */
     @Deprecated
-    public BuildHistory(final AbstractBuild<?, ?> baseline, final Class<? extends ResultAction<? extends BuildResult>> type,
+    public BuildHistory(final Run<?, ?> baseline, final Class<? extends ResultAction<? extends BuildResult>> type,
             final boolean useStableBuildAsReference) {
         this(baseline, type, false, useStableBuildAsReference);
     }

--- a/src/main/java/hudson/plugins/analysis/core/BuildResult.java
+++ b/src/main/java/hudson/plugins/analysis/core/BuildResult.java
@@ -224,28 +224,6 @@ public abstract class BuildResult implements ModelObject, Serializable, Annotati
     }
 
     /**
-     * Creates a new instance of {@link BuildResult}. Note that the warnings are
-     * not serialized anymore automatically. You need to call
-     * {@link #serializeAnnotations(Collection)} manually in your constructor to
-     * persist them.
-     *
-     * @param build
-     *            the current build as owner of this action
-     * @param history
-     *            build history
-     * @param result
-     *            the parsed result with all annotations
-     * @param defaultEncoding
-     *            the default encoding to be used when reading and parsing files
-     * @since 1.39
-     */
-    @Deprecated
-    protected BuildResult(final AbstractBuild<?, ?> build, final BuildHistory history,
-            final ParserResult result, final String defaultEncoding) {
-        initialize(history, build, defaultEncoding, result);
-    }
-
-    /**
      * Creates a new history based on the specified build.
      *
      * @param build
@@ -382,7 +360,7 @@ public abstract class BuildResult implements ModelObject, Serializable, Annotati
      */
     @Restricted(NoExternalUse.class)
     @Deprecated
-    public final Object getReferenceAbstractBuild(Run owner, Class targetClass) {
+    private final Object getReferenceAbstractBuild(Run owner, Class targetClass) {
       return owner instanceof AbstractBuild ? ((AbstractBuild) owner).getProject().getBuildByNumber(referenceBuild) : null;
     }
 
@@ -618,9 +596,8 @@ public abstract class BuildResult implements ModelObject, Serializable, Annotati
      * 
      * @see {@link WithBridgeMethods}
      */
-    @Restricted(NoExternalUse.class)
     @Deprecated
-    public final Object getAbstractBuild(Run owner, Class targetClass) {
+    private final Object getAbstractBuild(Run owner, Class targetClass) {
       return owner instanceof AbstractBuild ? (AbstractBuild) owner : null;
     }
 
@@ -1660,6 +1637,41 @@ public abstract class BuildResult implements ModelObject, Serializable, Annotati
     public BuildResult(final AbstractBuild<?, ?> build, final String defaultEncoding, final ParserResult result) {
         initialize(createHistory(build), build, defaultEncoding, result);
         serializeAnnotations(result.getAnnotations());
+    }
+
+    /**
+     * Creates a new instance of {@link BuildResult}. Note that the warnings are
+     * not serialized anymore automatically. You need to call
+     * {@link #serializeAnnotations(Collection)} manually in your constructor to
+     * persist them.
+     *
+     * @param build
+     *            the current build as owner of this action
+     * @param history
+     *            build history
+     * @param result
+     *            the parsed result with all annotations
+     * @param defaultEncoding
+     *            the default encoding to be used when reading and parsing files
+     * @since 1.39
+     */
+    @Deprecated
+    protected BuildResult(final AbstractBuild<?, ?> build, final BuildHistory history,
+            final ParserResult result, final String defaultEncoding) {
+        initialize(history, build, defaultEncoding, result);
+    }
+
+    /**
+     * Creates a new history based on the specified build.
+     *
+     * @param build
+     *            the build to start with
+     * @return the history
+     * @deprecated use {@link #createHistory(Run)} instead
+     */
+    @Deprecated
+    protected BuildHistory createHistory(final AbstractBuild<?, ?> build) {
+        return createHistory((Run<?, ?>) build);
     }
 
     // Backward compatibility. Do not remove.

--- a/src/main/java/hudson/plugins/analysis/core/BuildResult.java
+++ b/src/main/java/hudson/plugins/analysis/core/BuildResult.java
@@ -221,6 +221,28 @@ public abstract class BuildResult implements ModelObject, Serializable, Annotati
     }
 
     /**
+     * Creates a new instance of {@link BuildResult}. Note that the warnings are
+     * not serialized anymore automatically. You need to call
+     * {@link #serializeAnnotations(Collection)} manually in your constructor to
+     * persist them.
+     *
+     * @param build
+     *            the current build as owner of this action
+     * @param history
+     *            build history
+     * @param result
+     *            the parsed result with all annotations
+     * @param defaultEncoding
+     *            the default encoding to be used when reading and parsing files
+     * @since 1.39
+     */
+    @Deprecated
+    protected BuildResult(final AbstractBuild<?, ?> build, final BuildHistory history,
+            final ParserResult result, final String defaultEncoding) {
+        initialize(history, build, defaultEncoding, result);
+    }
+
+    /**
      * Creates a new history based on the specified build.
      *
      * @param build

--- a/src/main/java/hudson/plugins/analysis/core/BuildResult.java
+++ b/src/main/java/hudson/plugins/analysis/core/BuildResult.java
@@ -218,7 +218,7 @@ public abstract class BuildResult implements ModelObject, Serializable, Annotati
      *            the parsed result with all annotations
      * @param defaultEncoding
      *            the default encoding to be used when reading and parsing files
-     * @since 1.39
+     * @since 1.73
      */
     protected BuildResult(final Run<?, ?> build, final BuildHistory history,
             final ParserResult result, final String defaultEncoding) {
@@ -598,7 +598,7 @@ public abstract class BuildResult implements ModelObject, Serializable, Annotati
      * @see {@link WithBridgeMethods}
      */
     @Deprecated
-    private final Object getAbstractBuild(Run owner, Class targetClass) {
+    private Object getAbstractBuild(final Run owner, final Class targetClass) {
       return owner instanceof AbstractBuild ? (AbstractBuild) owner : null;
     }
 

--- a/src/main/java/hudson/plugins/analysis/core/BuildResult.java
+++ b/src/main/java/hudson/plugins/analysis/core/BuildResult.java
@@ -16,6 +16,8 @@ import java.util.logging.Logger;
 import org.apache.commons.lang.ObjectUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.time.DateUtils;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
@@ -23,6 +25,7 @@ import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
 
 import com.google.common.collect.Sets;
+import com.infradna.tool.bridge_method_injector.WithBridgeMethods;
 import com.thoughtworks.xstream.XStream;
 
 import jenkins.model.Jenkins;
@@ -591,8 +594,21 @@ public abstract class BuildResult implements ModelObject, Serializable, Annotati
      *
      * @return the owner
      */
+    @WithBridgeMethods(value=AbstractBuild.class, adapterMethod="getAbstractBuild")
     public Run<?, ?> getOwner() {
         return owner;
+    }
+
+    /**
+     * Added for backward compatibility. It generates <pre>AbstractBuild getOwner()</pre> bytecode during the build
+     * process, so old implementations can use that signature.
+     * 
+     * @see {@link WithBridgeMethods}
+     */
+    @Restricted(NoExternalUse.class)
+    @Deprecated
+    public final Object getAbstractBuild(Run owner, Class targetClass) {
+      return owner instanceof AbstractBuild ? (AbstractBuild) owner : null;
     }
 
     @Override

--- a/src/main/java/hudson/plugins/analysis/core/BuildResult.java
+++ b/src/main/java/hudson/plugins/analysis/core/BuildResult.java
@@ -369,8 +369,21 @@ public abstract class BuildResult implements ModelObject, Serializable, Annotati
      * @return the reference build.
      */
     @Exported
+    @WithBridgeMethods(value=AbstractBuild.class, adapterMethod="getReferenceAbstractBuild")
     public Run<?, ?> getReferenceBuild() {
         return owner.getParent().getBuildByNumber(referenceBuild);
+    }
+
+    /**
+     * Added for backward compatibility. It generates <pre>AbstractBuild getReferenceBuild()</pre> bytecode during the build
+     * process, so old implementations can use that signature.
+     * 
+     * @see {@link WithBridgeMethods}
+     */
+    @Restricted(NoExternalUse.class)
+    @Deprecated
+    public final Object getReferenceAbstractBuild(Run owner, Class targetClass) {
+      return owner instanceof AbstractBuild ? ((AbstractBuild) owner).getProject().getBuildByNumber(referenceBuild) : null;
     }
 
     private int computeDelta(final ParserResult result, final AnnotationContainer referenceResult, final Priority priority) {

--- a/src/main/java/hudson/plugins/analysis/core/BuildResult.java
+++ b/src/main/java/hudson/plugins/analysis/core/BuildResult.java
@@ -13,6 +13,8 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import javax.annotation.Nonnull;
+
 import org.apache.commons.lang.ObjectUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.time.DateUtils;
@@ -230,7 +232,7 @@ public abstract class BuildResult implements ModelObject, Serializable, Annotati
      *            the build to start with
      * @return the history
      */
-    protected BuildHistory createHistory(final Run<?, ?> build) {
+    protected BuildHistory createHistory(@Nonnull final Run<?, ?> build) {
         return new BuildHistory(build, getResultActionType(), false, false);
     }
 

--- a/src/main/java/hudson/plugins/analysis/core/BuildResult.java
+++ b/src/main/java/hudson/plugins/analysis/core/BuildResult.java
@@ -250,7 +250,7 @@ public abstract class BuildResult implements ModelObject, Serializable, Annotati
      * @return the history
      */
     protected BuildHistory createHistory(final Run<?, ?> build) {
-        return new BuildHistory(build, getResultActionType(), false);
+        return new BuildHistory(build, getResultActionType(), false, false);
     }
 
     /**

--- a/src/main/java/hudson/plugins/analysis/core/BuildResult.java
+++ b/src/main/java/hudson/plugins/analysis/core/BuildResult.java
@@ -360,7 +360,6 @@ public abstract class BuildResult implements ModelObject, Serializable, Annotati
      * 
      * @see {@link WithBridgeMethods}
      */
-    @Restricted(NoExternalUse.class)
     @Deprecated
     private final Object getReferenceAbstractBuild(Run owner, Class targetClass) {
       return owner instanceof AbstractBuild ? ((AbstractBuild) owner).getProject().getBuildByNumber(referenceBuild) : null;

--- a/src/main/java/hudson/plugins/analysis/core/BuildResult.java
+++ b/src/main/java/hudson/plugins/analysis/core/BuildResult.java
@@ -26,13 +26,15 @@ import com.google.common.collect.Sets;
 import com.thoughtworks.xstream.XStream;
 
 import jenkins.model.Jenkins;
-
 import hudson.XmlFile;
+
 import hudson.model.AbstractBuild;
 import hudson.model.Api;
 import hudson.model.Hudson;
+import hudson.model.Run;
 import hudson.model.ModelObject;
 import hudson.model.Result;
+
 import hudson.plugins.analysis.Messages;
 import hudson.plugins.analysis.util.HtmlPrinter;
 import hudson.plugins.analysis.util.PluginLogger;
@@ -79,7 +81,7 @@ public abstract class BuildResult implements ModelObject, Serializable, Annotati
     }
 
     /** Current build as owner of this action. */
-    private AbstractBuild<?, ?> owner;
+    private Run<?, ?> owner;
     /** All parsed modules. */
     private Set<String> modules;
     /** The total number of parsed modules (regardless if there are annotations). */
@@ -213,7 +215,7 @@ public abstract class BuildResult implements ModelObject, Serializable, Annotati
      *            the default encoding to be used when reading and parsing files
      * @since 1.39
      */
-    protected BuildResult(final AbstractBuild<?, ?> build, final BuildHistory history,
+    protected BuildResult(final Run<?, ?> build, final BuildHistory history,
             final ParserResult result, final String defaultEncoding) {
         initialize(history, build, defaultEncoding, result);
     }
@@ -225,7 +227,7 @@ public abstract class BuildResult implements ModelObject, Serializable, Annotati
      *            the build to start with
      * @return the history
      */
-    protected BuildHistory createHistory(final AbstractBuild<?, ?> build) {
+    protected BuildHistory createHistory(final Run<?, ?> build) {
         return new BuildHistory(build, getResultActionType(), false);
     }
 
@@ -261,7 +263,7 @@ public abstract class BuildResult implements ModelObject, Serializable, Annotati
      *            the history of build results of the associated plug-in
      */
     @SuppressWarnings("hiding")
-    private void initialize(final BuildHistory history, final AbstractBuild<?, ?> build, final String defaultEncoding, // NOCHECKSTYLE
+    private void initialize(final BuildHistory history, final Run<?, ?> build, final String defaultEncoding, // NOCHECKSTYLE
             final ParserResult result) {
         this.history = history;
         owner = build;
@@ -342,8 +344,8 @@ public abstract class BuildResult implements ModelObject, Serializable, Annotati
      * @return the reference build.
      */
     @Exported
-    public AbstractBuild<?, ?> getReferenceBuild() {
-        return owner.getProject().getBuildByNumber(referenceBuild);
+    public Run<?, ?> getReferenceBuild() {
+        return owner.getParent().getBuildByNumber(referenceBuild);
     }
 
     private int computeDelta(final ParserResult result, final AnnotationContainer referenceResult, final Priority priority) {
@@ -359,7 +361,7 @@ public abstract class BuildResult implements ModelObject, Serializable, Annotati
      * @param currentResult
      *            the current result
      */
-    private void computeZeroWarningsHighScore(final AbstractBuild<?, ?> build, final ParserResult currentResult) {
+    private void computeZeroWarningsHighScore(final Run<?, ?> build, final ParserResult currentResult) {
         if (history.hasPreviousResult()) {
             BuildResult previous = history.getPreviousResult();
             if (currentResult.hasNoAnnotations()) {
@@ -559,7 +561,7 @@ public abstract class BuildResult implements ModelObject, Serializable, Annotati
      * @return <code>true</code> if this result belongs to the last build
      */
     public boolean isCurrent() {
-        return getOwner().getProject().getLastBuild().number == getOwner().number;
+        return getOwner().getParent().getLastBuild().number == getOwner().number;
     }
 
     /**
@@ -567,7 +569,7 @@ public abstract class BuildResult implements ModelObject, Serializable, Annotati
      *
      * @return the owner
      */
-    public AbstractBuild<?, ?> getOwner() {
+    public Run<?, ?> getOwner() {
         return owner;
     }
 
@@ -1467,7 +1469,7 @@ public abstract class BuildResult implements ModelObject, Serializable, Annotati
     private String getReferenceBuildUrl() {
         HtmlPrinter printer = new HtmlPrinter();
         if (hasReferenceBuild()) {
-            AbstractBuild<?, ?> build = getReferenceBuild();
+            Run<?, ?> build = getReferenceBuild();
 
             printer.append("&nbsp;");
             printer.append("(");

--- a/src/main/java/hudson/plugins/analysis/core/FilesParser.java
+++ b/src/main/java/hudson/plugins/analysis/core/FilesParser.java
@@ -8,6 +8,7 @@ import java.util.Collection;
 import org.apache.commons.lang.ObjectUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.exception.ExceptionUtils;
+import org.jenkinsci.remoting.RoleChecker;
 
 import hudson.FilePath;
 import hudson.FilePath.FileCallable;
@@ -448,5 +449,10 @@ public class FilesParser implements FileCallable<ParserResult> {
             final AnnotationParser parser, final boolean shouldDetectModules,
             final boolean isMavenBuild) {
         this(filePattern, parser, isMavenBuild, StringUtils.EMPTY);
+    }
+
+    @Override
+    public void checkRoles(RoleChecker checker) throws SecurityException {
+        // TODO required in 1.580 (do we need to implement something here?)
     }
 }

--- a/src/main/java/hudson/plugins/analysis/core/FilesParser.java
+++ b/src/main/java/hudson/plugins/analysis/core/FilesParser.java
@@ -5,13 +5,13 @@ import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Collection;
 
+import jenkins.MasterToSlaveFileCallable;
+
 import org.apache.commons.lang.ObjectUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.exception.ExceptionUtils;
-import org.jenkinsci.remoting.RoleChecker;
 
 import hudson.FilePath;
-import hudson.FilePath.FileCallable;
 
 import hudson.plugins.analysis.Messages;
 import hudson.plugins.analysis.util.FileFinder;
@@ -29,7 +29,7 @@ import hudson.remoting.VirtualChannel;
  *
  * @author Ulli Hafner
  */
-public class FilesParser implements FileCallable<ParserResult> {
+public class FilesParser extends MasterToSlaveFileCallable<ParserResult> {
     private static final long serialVersionUID = -6415863872891783891L;
 
     /** Logs into a string. @since 1.20 */
@@ -449,10 +449,5 @@ public class FilesParser implements FileCallable<ParserResult> {
             final AnnotationParser parser, final boolean shouldDetectModules,
             final boolean isMavenBuild) {
         this(filePattern, parser, isMavenBuild, StringUtils.EMPTY);
-    }
-
-    @Override
-    public void checkRoles(RoleChecker checker) throws SecurityException {
-        // TODO required in 1.580 (do we need to implement something here?)
     }
 }

--- a/src/main/java/hudson/plugins/analysis/core/HealthAwarePublisher.java
+++ b/src/main/java/hudson/plugins/analysis/core/HealthAwarePublisher.java
@@ -103,8 +103,10 @@ public abstract class HealthAwarePublisher extends HealthAwareRecorder {
      * @param pluginName
      *            the name of the plug-in
      * @since 1.66
+     * @deprecated use {@link #HealthAwarePublisher(String)} and setters instead
      */
     @SuppressWarnings("PMD")
+    @Deprecated
     public HealthAwarePublisher(final String healthy, final String unHealthy,
             final String thresholdLimit, final String defaultEncoding,
             final boolean useDeltaValues, final String unstableTotalAll,
@@ -218,7 +220,7 @@ public abstract class HealthAwarePublisher extends HealthAwareRecorder {
      *             better understanding on why it failed.
      */
     @Deprecated
-    protected BuildResult perform(AbstractBuild<?, ?> build, PluginLogger logger)
+    public BuildResult perform(AbstractBuild<?, ?> build, PluginLogger logger)
             throws InterruptedException, IOException {
         return perform((Run) build, null, logger);
     }

--- a/src/main/java/hudson/plugins/analysis/core/HealthAwarePublisher.java
+++ b/src/main/java/hudson/plugins/analysis/core/HealthAwarePublisher.java
@@ -242,7 +242,7 @@ public abstract class HealthAwarePublisher extends HealthAwareRecorder {
     /**
      * Util.isOverriden does not work on non-public methods, that's why this one is used here.
      */
-    private static boolean isOverridden(@Nonnull Class base, @Nonnull Class derived, @Nonnull String methodName, @Nonnull Class... types) {
+    /*package*/ static boolean isOverridden(@Nonnull Class base, @Nonnull Class derived, @Nonnull String methodName, @Nonnull Class... types) {
         try {
             return !getMethod(base, methodName, types).equals(getMethod(derived, methodName, types));
         } catch (NoSuchMethodException e) {

--- a/src/main/java/hudson/plugins/analysis/core/HealthAwarePublisher.java
+++ b/src/main/java/hudson/plugins/analysis/core/HealthAwarePublisher.java
@@ -12,6 +12,7 @@ import hudson.model.Result;
 import hudson.model.AbstractBuild;
 import hudson.model.Run;
 
+import hudson.plugins.analysis.util.Compatibility;
 import hudson.plugins.analysis.util.PluginLogger;
 
 import hudson.tasks.BuildStep;
@@ -228,7 +229,7 @@ public abstract class HealthAwarePublisher extends HealthAwareRecorder {
     }
 
     protected /*abstract*/ BuildResult perform(Run<?, ?> run, FilePath workspace, PluginLogger logger) throws InterruptedException, IOException{
-        if (run instanceof AbstractBuild && isOverridden(HealthAwarePublisher.class, getClass(),
+        if (run instanceof AbstractBuild && Compatibility.isOverridden(HealthAwarePublisher.class, getClass(),
                 "perform", AbstractBuild.class, PluginLogger.class)) {
             return perform((AbstractBuild) run, logger);
         }
@@ -236,36 +237,6 @@ public abstract class HealthAwarePublisher extends HealthAwareRecorder {
             // Runtime error to force overriding this method
             throw new AbstractMethodError("you must override the new overload of perform(Run, FilePath, Launcher, PluginLogger)");
         }
-    }
-
-    /**
-     * Util.isOverriden does not work on non-public methods, that's why this one is used here.
-     */
-    /*package*/ static boolean isOverridden(@Nonnull Class base, @Nonnull Class derived, @Nonnull String methodName, @Nonnull Class... types) {
-        try {
-            return !getMethod(base, methodName, types).equals(getMethod(derived, methodName, types));
-        } catch (NoSuchMethodException e) {
-            throw new AssertionError(e);
-        }
-    }
-
-    private static Method getMethod(@Nonnull Class clazz, @Nonnull String methodName, @Nonnull Class... types) throws NoSuchMethodException {
-        Method res = null;
-        try {
-            res = clazz.getDeclaredMethod(methodName, types);
-        } catch (NoSuchMethodException e) {
-            // Method not found in clazz, let's search in superclasses
-            Class superclass = clazz.getSuperclass();
-            if (superclass != null) {
-                res = getMethod(superclass, methodName, types);
-            }
-        } catch (SecurityException e) {
-            throw new AssertionError(e);
-        }
-        if (res == null) {
-            throw new NoSuchMethodException("Method " + methodName + " not found in " + clazz.getName());
-        }
-        return res;
     }
 
     // CHECKSTYLE:OFF

--- a/src/main/java/hudson/plugins/analysis/core/HealthAwarePublisher.java
+++ b/src/main/java/hudson/plugins/analysis/core/HealthAwarePublisher.java
@@ -231,7 +231,8 @@ public abstract class HealthAwarePublisher extends HealthAwareRecorder {
         if (run instanceof AbstractBuild && isOverridden(HealthAwarePublisher.class, getClass(),
                 "perform", AbstractBuild.class, PluginLogger.class)) {
             return perform((AbstractBuild) run, logger);
-        } else {
+        }
+        else {
             // Runtime error to force overriding this method
             throw new AbstractMethodError("you must override the new overload of perform(Run, FilePath, Launcher, PluginLogger)");
         }

--- a/src/main/java/hudson/plugins/analysis/core/HealthAwarePublisher.java
+++ b/src/main/java/hudson/plugins/analysis/core/HealthAwarePublisher.java
@@ -1,9 +1,6 @@
 package hudson.plugins.analysis.core;
 
 import java.io.IOException;
-import java.lang.reflect.Method;
-
-import javax.annotation.Nonnull;
 
 import hudson.FilePath;
 import hudson.Launcher;
@@ -31,111 +28,16 @@ import hudson.tasks.BuildStep;
  *
  * @author Ulli Hafner
  */
-// CHECKSTYLE:OFF
 public abstract class HealthAwarePublisher extends HealthAwareRecorder {
     private static final long serialVersionUID = -4225952809165635796L;
 
     /**
-     * Creates a new instance of {@link HealthAwarePublisher}.
+     * Constructor using only required field/s.
+     * Use setters to initialize the object if needed.
      *
-     * @param healthy
-     *            Report health as 100% when the number of open tasks is less
-     *            than this value
-     * @param unHealthy
-     *            Report health as 0% when the number of open tasks is greater
-     *            than this value
-     * @param thresholdLimit
-     *            determines which warning priorities should be considered when
-     *            evaluating the build stability and health
-     * @param defaultEncoding
-     *            the default encoding to be used when reading and parsing files
-     * @param useDeltaValues
-     *            determines whether the absolute annotations delta or the
-     *            actual annotations set difference should be used to evaluate
-     *            the build stability
-     * @param unstableTotalAll
-     *            annotation threshold
-     * @param unstableTotalHigh
-     *            annotation threshold
-     * @param unstableTotalNormal
-     *            annotation threshold
-     * @param unstableTotalLow
-     *            annotation threshold
-     * @param unstableNewAll
-     *            annotation threshold
-     * @param unstableNewHigh
-     *            annotation threshold
-     * @param unstableNewNormal
-     *            annotation threshold
-     * @param unstableNewLow
-     *            annotation threshold
-     * @param failedTotalAll
-     *            annotation threshold
-     * @param failedTotalHigh
-     *            annotation threshold
-     * @param failedTotalNormal
-     *            annotation threshold
-     * @param failedTotalLow
-     *            annotation threshold
-     * @param failedNewAll
-     *            annotation threshold
-     * @param failedNewHigh
-     *            annotation threshold
-     * @param failedNewNormal
-     *            annotation threshold
-     * @param failedNewLow
-     *            annotation threshold
-     * @param canRunOnFailed
-     *            determines whether the plug-in can run for failed builds, too
-     * @param usePreviousBuildAsReference
-     *            determine if the previous build should always be used as the
-     *            reference build, no matter its overall result.
-     * @param useStableBuildAsReference
-     *            determines whether only stable builds should be used as
-     *            reference builds or not
-     * @param shouldDetectModules
-     *            determines whether module names should be derived from Maven
-     *            POM or Ant build files
-     * @param canComputeNew
-     *            determines whether new warnings should be computed (with
-     *            respect to baseline)
-     * @param canResolveRelativePaths
-     *            determines whether relative paths in warnings should be
-     *            resolved using a time expensive operation that scans the whole
-     *            workspace for matching files.
-     * @param pluginName
-     *            the name of the plug-in
-     * @since 1.66
-     * @deprecated use {@link #HealthAwarePublisher(String)} and setters instead
+     * @param pluginName the plugin name
      */
-    @SuppressWarnings("PMD")
-    @Deprecated
-    public HealthAwarePublisher(final String healthy, final String unHealthy,
-            final String thresholdLimit, final String defaultEncoding,
-            final boolean useDeltaValues, final String unstableTotalAll,
-            final String unstableTotalHigh, final String unstableTotalNormal,
-            final String unstableTotalLow, final String unstableNewAll,
-            final String unstableNewHigh, final String unstableNewNormal,
-            final String unstableNewLow, final String failedTotalAll, final String failedTotalHigh,
-            final String failedTotalNormal, final String failedTotalLow, final String failedNewAll,
-            final String failedNewHigh, final String failedNewNormal, final String failedNewLow,
-            final boolean canRunOnFailed,
-            final boolean usePreviousBuildAsReference,
-            final boolean useStableBuildAsReference,
-            final boolean shouldDetectModules, final boolean canComputeNew,
-            final boolean canResolveRelativePaths, final String pluginName) {
-        super(healthy, unHealthy, thresholdLimit, defaultEncoding,
-                useDeltaValues, unstableTotalAll, unstableTotalHigh,
-                unstableTotalNormal, unstableTotalLow, unstableNewAll,
-                unstableNewHigh, unstableNewNormal, unstableNewLow,
-                failedTotalAll, failedTotalHigh, failedTotalNormal,
-                failedTotalLow, failedNewAll, failedNewHigh, failedNewNormal,
-                failedNewLow, canRunOnFailed, usePreviousBuildAsReference,
-                useStableBuildAsReference, shouldDetectModules, canComputeNew,
-                canResolveRelativePaths, pluginName);
-    }
-
-    public HealthAwarePublisher(String pluginName) {
+    public HealthAwarePublisher(final String pluginName) {
         super(pluginName);
     }
 
@@ -144,8 +46,10 @@ public abstract class HealthAwarePublisher extends HealthAwareRecorder {
      * implementation provides a template method that updates the build status based on the results and copies all files
      * with warnings to the build folder on the master.
      *
-     * @param build
+     * @param run
      *            current build
+     * @param workspace
+     *            the workspace for this build
      * @param launcher
      *            the launcher for this build
      * @param logger
@@ -157,7 +61,7 @@ public abstract class HealthAwarePublisher extends HealthAwareRecorder {
      *             if the user canceled the build
      */
     @Override
-    protected boolean perform(Run<?, ?> run, FilePath workspace, Launcher launcher, PluginLogger logger)
+    protected boolean perform(final Run<?, ?> run, final FilePath workspace, final Launcher launcher, final PluginLogger logger)
             throws IOException, InterruptedException {
         BuildResult result;
         try {
@@ -359,5 +263,105 @@ public abstract class HealthAwarePublisher extends HealthAwareRecorder {
                 failedTotalHigh, failedTotalNormal, failedTotalLow, failedNewAll, failedNewHigh,
                 failedNewNormal, failedNewLow, canRunOnFailed, shouldDetectModules, canComputeNew,
                 true, pluginName);
+    }
+
+    /**
+     * Creates a new instance of {@link HealthAwarePublisher}.
+     *
+     * @param healthy
+     *            Report health as 100% when the number of open tasks is less
+     *            than this value
+     * @param unHealthy
+     *            Report health as 0% when the number of open tasks is greater
+     *            than this value
+     * @param thresholdLimit
+     *            determines which warning priorities should be considered when
+     *            evaluating the build stability and health
+     * @param defaultEncoding
+     *            the default encoding to be used when reading and parsing files
+     * @param useDeltaValues
+     *            determines whether the absolute annotations delta or the
+     *            actual annotations set difference should be used to evaluate
+     *            the build stability
+     * @param unstableTotalAll
+     *            annotation threshold
+     * @param unstableTotalHigh
+     *            annotation threshold
+     * @param unstableTotalNormal
+     *            annotation threshold
+     * @param unstableTotalLow
+     *            annotation threshold
+     * @param unstableNewAll
+     *            annotation threshold
+     * @param unstableNewHigh
+     *            annotation threshold
+     * @param unstableNewNormal
+     *            annotation threshold
+     * @param unstableNewLow
+     *            annotation threshold
+     * @param failedTotalAll
+     *            annotation threshold
+     * @param failedTotalHigh
+     *            annotation threshold
+     * @param failedTotalNormal
+     *            annotation threshold
+     * @param failedTotalLow
+     *            annotation threshold
+     * @param failedNewAll
+     *            annotation threshold
+     * @param failedNewHigh
+     *            annotation threshold
+     * @param failedNewNormal
+     *            annotation threshold
+     * @param failedNewLow
+     *            annotation threshold
+     * @param canRunOnFailed
+     *            determines whether the plug-in can run for failed builds, too
+     * @param usePreviousBuildAsReference
+     *            determine if the previous build should always be used as the
+     *            reference build, no matter its overall result.
+     * @param useStableBuildAsReference
+     *            determines whether only stable builds should be used as
+     *            reference builds or not
+     * @param shouldDetectModules
+     *            determines whether module names should be derived from Maven
+     *            POM or Ant build files
+     * @param canComputeNew
+     *            determines whether new warnings should be computed (with
+     *            respect to baseline)
+     * @param canResolveRelativePaths
+     *            determines whether relative paths in warnings should be
+     *            resolved using a time expensive operation that scans the whole
+     *            workspace for matching files.
+     * @param pluginName
+     *            the name of the plug-in
+     * @since 1.66
+     * @deprecated use {@link #HealthAwarePublisher(String)} and setters instead
+     */
+    @SuppressWarnings("PMD")
+    @Deprecated
+    public HealthAwarePublisher(final String healthy, final String unHealthy,
+            final String thresholdLimit, final String defaultEncoding,
+            final boolean useDeltaValues, final String unstableTotalAll,
+            final String unstableTotalHigh, final String unstableTotalNormal,
+            final String unstableTotalLow, final String unstableNewAll,
+            final String unstableNewHigh, final String unstableNewNormal,
+            final String unstableNewLow, final String failedTotalAll, final String failedTotalHigh,
+            final String failedTotalNormal, final String failedTotalLow, final String failedNewAll,
+            final String failedNewHigh, final String failedNewNormal, final String failedNewLow,
+            final boolean canRunOnFailed,
+            final boolean usePreviousBuildAsReference,
+            final boolean useStableBuildAsReference,
+            final boolean shouldDetectModules, final boolean canComputeNew,
+            final boolean canResolveRelativePaths, final String pluginName) {
+        super(healthy, unHealthy, thresholdLimit, defaultEncoding,
+                useDeltaValues, unstableTotalAll, unstableTotalHigh,
+                unstableTotalNormal, unstableTotalLow, unstableNewAll,
+                unstableNewHigh, unstableNewNormal, unstableNewLow,
+                failedTotalAll, failedTotalHigh, failedTotalNormal,
+                failedTotalLow, failedNewAll, failedNewHigh, failedNewNormal,
+                failedNewLow, canRunOnFailed, usePreviousBuildAsReference,
+                useStableBuildAsReference, shouldDetectModules, canComputeNew,
+                canResolveRelativePaths, pluginName);
     }
 }

--- a/src/main/java/hudson/plugins/analysis/core/HealthAwarePublisher.java
+++ b/src/main/java/hudson/plugins/analysis/core/HealthAwarePublisher.java
@@ -1,13 +1,11 @@
 package hudson.plugins.analysis.core;
 
 import java.io.IOException;
-import java.lang.reflect.Method;
 
 import javax.annotation.Nonnull;
 
 import hudson.FilePath;
 import hudson.Launcher;
-import hudson.Util;
 
 import hudson.model.Result;
 import hudson.model.AbstractBuild;

--- a/src/main/java/hudson/plugins/analysis/core/HealthAwarePublisher.java
+++ b/src/main/java/hudson/plugins/analysis/core/HealthAwarePublisher.java
@@ -5,8 +5,6 @@ import java.lang.reflect.Method;
 
 import javax.annotation.Nonnull;
 
-import org.apache.commons.httpclient.methods.GetMethod;
-
 import hudson.FilePath;
 import hudson.Launcher;
 
@@ -230,8 +228,8 @@ public abstract class HealthAwarePublisher extends HealthAwareRecorder {
     }
 
     protected /*abstract*/ BuildResult perform(Run<?, ?> run, FilePath workspace, PluginLogger logger) throws InterruptedException, IOException{
-        if (isOverridden(HealthAwarePublisher.class, getClass(),
-                "perform", AbstractBuild.class, PluginLogger.class) && run instanceof AbstractBuild) {
+        if (run instanceof AbstractBuild && isOverridden(HealthAwarePublisher.class, getClass(),
+                "perform", AbstractBuild.class, PluginLogger.class)) {
             return perform((AbstractBuild) run, logger);
         } else {
             // Runtime error to force overriding this method

--- a/src/main/java/hudson/plugins/analysis/core/HealthAwareRecorder.java
+++ b/src/main/java/hudson/plugins/analysis/core/HealthAwareRecorder.java
@@ -549,6 +549,7 @@ public abstract class HealthAwareRecorder extends Recorder implements HealthDesc
      * @return the 100% healthiness
      */
     @Override
+    @CheckForNull
     public String getHealthy() {
         return healthy;
     }
@@ -567,6 +568,7 @@ public abstract class HealthAwareRecorder extends Recorder implements HealthDesc
      * @return the 0% unhealthiness
      */
     @Override
+    @CheckForNull
     public String getUnHealthy() {
         return unHealthy;
     }
@@ -663,6 +665,7 @@ public abstract class HealthAwareRecorder extends Recorder implements HealthDesc
      *
      * @return the threshold limit
      */
+    @CheckForNull
     public String getThresholdLimit() {
         return thresholdLimit;
     }
@@ -702,6 +705,7 @@ public abstract class HealthAwareRecorder extends Recorder implements HealthDesc
         dontComputeNew = !canComputeNew;
     }
 
+    @CheckForNull
     public String getUnstableTotalAll() {
         return thresholds.unstableTotalHigh;
     }
@@ -711,6 +715,7 @@ public abstract class HealthAwareRecorder extends Recorder implements HealthDesc
         thresholds.unstableTotalAll = unstableTotalAll;
     }
 
+    @CheckForNull
     public String getUnstableTotalHigh() {
         return thresholds.unstableTotalHigh;
     }
@@ -720,6 +725,7 @@ public abstract class HealthAwareRecorder extends Recorder implements HealthDesc
         thresholds.unstableTotalHigh = unstableTotalHigh;
     }
 
+    @CheckForNull
     public String getUnstableTotalNormal() {
         return thresholds.unstableTotalNormal;
     }
@@ -729,6 +735,7 @@ public abstract class HealthAwareRecorder extends Recorder implements HealthDesc
         thresholds.unstableTotalNormal = unstableTotalNormal;
     }
 
+    @CheckForNull
     public String getUnstableTotalLow() {
         return thresholds.unstableTotalLow;
     }
@@ -738,6 +745,7 @@ public abstract class HealthAwareRecorder extends Recorder implements HealthDesc
         thresholds.unstableTotalLow = unstableTotalLow;
     }
 
+    @CheckForNull
     public String getUnstableNewAll() {
         return thresholds.unstableNewAll;
     }
@@ -747,6 +755,7 @@ public abstract class HealthAwareRecorder extends Recorder implements HealthDesc
         thresholds.unstableNewAll = unstableNewAll;
     }
 
+    @CheckForNull
     public String getUnstableNewHigh() {
         return thresholds.unstableNewHigh;
     }
@@ -756,6 +765,7 @@ public abstract class HealthAwareRecorder extends Recorder implements HealthDesc
         thresholds.unstableNewHigh = unstableNewHigh;
     }
 
+    @CheckForNull
     public String getUnstableNewNormal() {
         return thresholds.unstableNewNormal;
     }
@@ -765,6 +775,7 @@ public abstract class HealthAwareRecorder extends Recorder implements HealthDesc
         thresholds.unstableNewNormal = unstableNewNormal;
     }
 
+    @CheckForNull
     public String getUnstableNewLow() {
         return thresholds.unstableNewLow;
     }
@@ -774,6 +785,7 @@ public abstract class HealthAwareRecorder extends Recorder implements HealthDesc
         thresholds.unstableNewLow = unstableNewLow;
     }
 
+    @CheckForNull
     public String getFailedTotalAll() {
         return thresholds.failedTotalAll;
     }
@@ -783,6 +795,7 @@ public abstract class HealthAwareRecorder extends Recorder implements HealthDesc
         thresholds.failedTotalAll = failedTotalAll;
     }
 
+    @CheckForNull
     public String getFailedTotalHigh() {
         return thresholds.failedTotalHigh;
     }
@@ -792,6 +805,7 @@ public abstract class HealthAwareRecorder extends Recorder implements HealthDesc
         thresholds.failedTotalHigh = failedTotalHigh;
     }
 
+    @CheckForNull
     public String getFailedTotalNormal() {
         return thresholds.failedTotalNormal;
     }
@@ -801,6 +815,7 @@ public abstract class HealthAwareRecorder extends Recorder implements HealthDesc
         thresholds.failedTotalNormal = failedTotalNormal;
     }
 
+    @CheckForNull
     public String getFailedTotalLow() {
         return thresholds.failedTotalNormal;
     }
@@ -810,6 +825,7 @@ public abstract class HealthAwareRecorder extends Recorder implements HealthDesc
         thresholds.failedTotalLow = failedTotalLow;
     }
 
+    @CheckForNull
     public String getFailedNewAll() {
         return thresholds.failedNewAll;
     }
@@ -819,6 +835,7 @@ public abstract class HealthAwareRecorder extends Recorder implements HealthDesc
         thresholds.failedNewAll = failedNewAll;
     }
 
+    @CheckForNull
     public String getFailedNewHigh() {
         return thresholds.failedNewHigh;
     }
@@ -828,6 +845,7 @@ public abstract class HealthAwareRecorder extends Recorder implements HealthDesc
         thresholds.failedNewHigh = failedNewHigh;
     }
 
+    @CheckForNull
     public String getFailedNewNormal() {
         return thresholds.failedNewNormal;
     }
@@ -837,6 +855,7 @@ public abstract class HealthAwareRecorder extends Recorder implements HealthDesc
         thresholds.failedNewNormal = failedNewNormal;
     }
 
+    @CheckForNull
     public String getFailedNewLow() {
         return thresholds.failedNewLow;
     }

--- a/src/main/java/hudson/plugins/analysis/core/HealthAwareRecorder.java
+++ b/src/main/java/hudson/plugins/analysis/core/HealthAwareRecorder.java
@@ -607,19 +607,33 @@ public abstract class HealthAwareRecorder extends Recorder implements HealthDesc
      */
     protected boolean isMavenBuild(final Run<?, ?> build) {
         if (build instanceof AbstractBuild) {
-            AbstractBuild aBuild = (AbstractBuild) build;
-            if (aBuild.getProject() instanceof Project) {
-                Project<?, ?> project = (Project<?, ?>) aBuild.getProject();
-                for (Builder builder : project.getBuilders()) {
-                    if (builder instanceof Maven) {
-                        return true;
-                    }
-                }
-            }
-            return false;
+            return isMavenBuild((AbstractBuild) build);
         } else {
             return false;
         }
+    }
+
+    /**
+     * Returns whether the current build uses maven.
+     *
+     * @param build
+     *            the current build
+     * @return <code>true</code> if the current build uses maven,
+     *         <code>false</code> otherwise
+     * @deprecated use {@link #isMavenBuild(Run)} instead
+     */
+    @Deprecated
+    protected boolean isMavenBuild(final AbstractBuild<?, ?> build) {
+        AbstractBuild aBuild = (AbstractBuild) build;
+        if (aBuild.getProject() instanceof Project) {
+            Project<?, ?> project = (Project<?, ?>) aBuild.getProject();
+            for (Builder builder : project.getBuilders()) {
+                if (builder instanceof Maven) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     /**

--- a/src/main/java/hudson/plugins/analysis/core/HealthAwareRecorder.java
+++ b/src/main/java/hudson/plugins/analysis/core/HealthAwareRecorder.java
@@ -605,16 +605,21 @@ public abstract class HealthAwareRecorder extends Recorder implements HealthDesc
      * @return <code>true</code> if the current build uses maven,
      *         <code>false</code> otherwise
      */
-    protected boolean isMavenBuild(final AbstractBuild<?, ?> build) {
-        if (build.getProject() instanceof Project) {
-            Project<?, ?> project = (Project<?, ?>)build.getProject();
-            for (Builder builder : project.getBuilders()) {
-                if (builder instanceof Maven) {
-                    return true;
+    protected boolean isMavenBuild(final Run<?, ?> build) {
+        if (build instanceof AbstractBuild) {
+            AbstractBuild aBuild = (AbstractBuild) build;
+            if (aBuild.getProject() instanceof Project) {
+                Project<?, ?> project = (Project<?, ?>) aBuild.getProject();
+                for (Builder builder : project.getBuilders()) {
+                    if (builder instanceof Maven) {
+                        return true;
+                    }
                 }
             }
+            return false;
+        } else {
+            return false;
         }
-        return false;
     }
 
     /**

--- a/src/main/java/hudson/plugins/analysis/core/HealthAwareRecorder.java
+++ b/src/main/java/hudson/plugins/analysis/core/HealthAwareRecorder.java
@@ -247,7 +247,7 @@ public abstract class HealthAwareRecorder extends Recorder implements HealthDesc
 
     // CHECKSTYLE:ON
 
-    public HealthAwareRecorder(String pluginName) {
+    protected HealthAwareRecorder(String pluginName) {
         this.pluginName = "[" + pluginName + "] ";
     }
 

--- a/src/main/java/hudson/plugins/analysis/core/HealthAwareRecorder.java
+++ b/src/main/java/hudson/plugins/analysis/core/HealthAwareRecorder.java
@@ -123,130 +123,13 @@ public abstract class HealthAwareRecorder extends Recorder implements HealthDesc
      */
     private boolean doNotResolveRelativePaths;
 
-    /**
-     * Creates a new instance of {@link HealthAwareRecorder}.
-     *
-     * @param healthy
-     *            Report health as 100% when the number of open tasks is less
-     *            than this value
-     * @param unHealthy
-     *            Report health as 0% when the number of open tasks is greater
-     *            than this value
-     * @param thresholdLimit
-     *            determines which warning priorities should be considered when
-     *            evaluating the build stability and health
-     * @param defaultEncoding
-     *            the default encoding to be used when reading and parsing files
-     * @param useDeltaValues
-     *            determines whether the absolute annotations delta or the
-     *            actual annotations set difference should be used to evaluate
-     *            the build stability
-     * @param unstableTotalAll
-     *            annotation threshold
-     * @param unstableTotalHigh
-     *            annotation threshold
-     * @param unstableTotalNormal
-     *            annotation threshold
-     * @param unstableTotalLow
-     *            annotation threshold
-     * @param unstableNewAll
-     *            annotation threshold
-     * @param unstableNewHigh
-     *            annotation threshold
-     * @param unstableNewNormal
-     *            annotation threshold
-     * @param unstableNewLow
-     *            annotation threshold
-     * @param failedTotalAll
-     *            annotation threshold
-     * @param failedTotalHigh
-     *            annotation threshold
-     * @param failedTotalNormal
-     *            annotation threshold
-     * @param failedTotalLow
-     *            annotation threshold
-     * @param failedNewAll
-     *            annotation threshold
-     * @param failedNewHigh
-     *            annotation threshold
-     * @param failedNewNormal
-     *            annotation threshold
-     * @param failedNewLow
-     *            annotation threshold
-     * @param canRunOnFailed
-     *            determines whether the plug-in can run for failed builds, too
-     * @param usePreviousBuildAsReference
-     *            determine if the previous build should always be used as the
-     *            reference build, no matter its overall result.
-     * @param useStableBuildAsReference
-     *            determines whether only stable builds should be used as
-     *            reference builds or not
-     * @param shouldDetectModules
-     *            determines whether module names should be derived from Maven
-     *            POM or Ant build files
-     * @param canComputeNew
-     *            determines whether new warnings should be computed (with
-     *            respect to baseline)
-     * @param canResolveRelativePaths
-     *            determines whether relative paths in warnings should be
-     *            resolved using a time expensive operation that scans the whole
-     *            workspace for matching files.
-     * @param pluginName
-     *            the name of the plug-in
-     * @deprecated use setters instead
-     */
-    // CHECKSTYLE:OFF
-    @SuppressWarnings("PMD")
-    @Deprecated
-    public HealthAwareRecorder(final String healthy, final String unHealthy,
-            final String thresholdLimit, final String defaultEncoding,
-            final boolean useDeltaValues, final String unstableTotalAll,
-            final String unstableTotalHigh, final String unstableTotalNormal,
-            final String unstableTotalLow, final String unstableNewAll,
-            final String unstableNewHigh, final String unstableNewNormal,
-            final String unstableNewLow, final String failedTotalAll, final String failedTotalHigh,
-            final String failedTotalNormal, final String failedTotalLow, final String failedNewAll,
-            final String failedNewHigh, final String failedNewNormal, final String failedNewLow,
-            final boolean canRunOnFailed, final boolean usePreviousBuildAsReference,
-            final boolean useStableBuildAsReference,
-            final boolean shouldDetectModules, final boolean canComputeNew,
-            final boolean canResolveRelativePaths, final String pluginName) {
-        super();
-        this.healthy = healthy;
-        this.unHealthy = unHealthy;
-        this.thresholdLimit = StringUtils.defaultIfEmpty(thresholdLimit, DEFAULT_PRIORITY_THRESHOLD_LIMIT);
-        this.defaultEncoding = defaultEncoding;
-        this.useDeltaValues = useDeltaValues;
-
-        doNotResolveRelativePaths = !canResolveRelativePaths;
-        dontComputeNew = !canComputeNew;
-
-        thresholds.unstableTotalAll = unstableTotalAll;
-        thresholds.unstableTotalHigh = unstableTotalHigh;
-        thresholds.unstableTotalNormal = unstableTotalNormal;
-        thresholds.unstableTotalLow = unstableTotalLow;
-        thresholds.unstableNewAll = unstableNewAll;
-        thresholds.unstableNewHigh = unstableNewHigh;
-        thresholds.unstableNewNormal = unstableNewNormal;
-        thresholds.unstableNewLow = unstableNewLow;
-        thresholds.failedTotalAll = failedTotalAll;
-        thresholds.failedTotalHigh = failedTotalHigh;
-        thresholds.failedTotalNormal = failedTotalNormal;
-        thresholds.failedTotalLow = failedTotalLow;
-        thresholds.failedNewAll = failedNewAll;
-        thresholds.failedNewHigh = failedNewHigh;
-        thresholds.failedNewNormal = failedNewNormal;
-        thresholds.failedNewLow = failedNewLow;
-
-        this.canRunOnFailed = canRunOnFailed;
-        this.usePreviousBuildAsReference = usePreviousBuildAsReference;
-        this.useStableBuildAsReference = useStableBuildAsReference;
-        this.shouldDetectModules = shouldDetectModules;
-        this.pluginName = "[" + pluginName + "] ";
-    }
-
     // CHECKSTYLE:ON
-
+    /**
+     * Constructor using only required field/s.
+     * Use setters to initialize the object if needed.
+     *
+     * @param pluginName the plugin name
+     */
     protected HealthAwareRecorder(String pluginName) {
         this.pluginName = "[" + pluginName + "] ";
     }
@@ -307,7 +190,7 @@ public abstract class HealthAwareRecorder extends Recorder implements HealthDesc
      * @see {@link #getUsePreviousBuildAsReference}
      */
     @DataBoundSetter
-    public void setUsePreviousBuildAsReference(boolean usePreviousBuildAsReference) {
+    public void setUsePreviousBuildAsReference(final boolean usePreviousBuildAsReference) {
         this.usePreviousBuildAsReference = usePreviousBuildAsReference;
     }
 
@@ -325,7 +208,7 @@ public abstract class HealthAwareRecorder extends Recorder implements HealthDesc
      * @see {@link #getUseStableBuildAsReference}
      */
     @DataBoundSetter
-    public void setUseStableBuildAsReference(boolean useStableBuildAsReference) {
+    public void setUseStableBuildAsReference(final boolean useStableBuildAsReference) {
         this.useStableBuildAsReference = useStableBuildAsReference;
     }
 
@@ -372,7 +255,7 @@ public abstract class HealthAwareRecorder extends Recorder implements HealthDesc
     }
 
     @Override
-    public void perform(Run<?, ?> run, FilePath workspace, Launcher launcher, TaskListener listener)
+    public final void perform(final Run<?, ?> run, final FilePath workspace, final Launcher launcher, final TaskListener listener)
             throws InterruptedException, IOException {
         PluginLogger logger = new LoggerFactory().createLogger(listener.getLogger(), pluginName);
         if (canContinue(run.getResult())) {
@@ -387,8 +270,10 @@ public abstract class HealthAwareRecorder extends Recorder implements HealthDesc
      * Callback method that is invoked after the build where this recorder can
      * collect the results.
      *
-     * @param build
+     * @param run
      *            current build
+     * @param workspace
+     *            the workspace for this build
      * @param launcher
      *            the launcher for this build
      * @param logger
@@ -467,7 +352,7 @@ public abstract class HealthAwareRecorder extends Recorder implements HealthDesc
      * @see {@link #getCanRunOnFailed()}
      */
     @DataBoundSetter
-    public void setCanRunOnFailed(boolean canRunOnFailed) {
+    public void setCanRunOnFailed(final boolean canRunOnFailed) {
         this.canRunOnFailed = canRunOnFailed;
     }
 
@@ -485,7 +370,7 @@ public abstract class HealthAwareRecorder extends Recorder implements HealthDesc
      * @see {@link #getShouldDetectModules()}
      */
     @DataBoundSetter
-    public void setShouldDetectModules(boolean shouldDetectModules) {
+    public void setShouldDetectModules(final boolean shouldDetectModules) {
         this.shouldDetectModules = shouldDetectModules;
     }
 
@@ -539,7 +424,7 @@ public abstract class HealthAwareRecorder extends Recorder implements HealthDesc
      * @see {@link #getUseDeltaValues()}
      */
     @DataBoundSetter
-    public void setUseDeltaValues(boolean useDeltaValues) {
+    public void setUseDeltaValues(final boolean useDeltaValues) {
         this.useDeltaValues = useDeltaValues;
     }
 
@@ -558,7 +443,7 @@ public abstract class HealthAwareRecorder extends Recorder implements HealthDesc
      * @see {@link #getHealthy()}
      */
     @DataBoundSetter
-    public void setHealthy(String healthy) {
+    public void setHealthy(final String healthy) {
         this.healthy = healthy;
     }
 
@@ -577,7 +462,7 @@ public abstract class HealthAwareRecorder extends Recorder implements HealthDesc
      * @see {@link #getUnHealthy()}
      */
     @DataBoundSetter
-    public void setUnHealthy(String unHealthy) {
+    public void setUnHealthy(final String unHealthy) {
         this.unHealthy = unHealthy;
     }
 
@@ -595,7 +480,7 @@ public abstract class HealthAwareRecorder extends Recorder implements HealthDesc
      * @see {@link #getDefaultEncoding()}
      */
     @DataBoundSetter
-    public void setDefaultEncoding(String defaultEncoding) {
+    public void setDefaultEncoding(final String defaultEncoding) {
         this.defaultEncoding = defaultEncoding;
     }
 
@@ -674,7 +559,7 @@ public abstract class HealthAwareRecorder extends Recorder implements HealthDesc
      * @see {@link #getThresholdLimit()}
      */
     @DataBoundSetter
-    public void setThresholdLimit(String thresholdLimit) {
+    public void setThresholdLimit(final String thresholdLimit) {
         this.thresholdLimit = StringUtils.defaultIfEmpty(thresholdLimit, DEFAULT_PRIORITY_THRESHOLD_LIMIT);
     }
 
@@ -690,7 +575,7 @@ public abstract class HealthAwareRecorder extends Recorder implements HealthDesc
      *  Useful when defining the groovy script in workflow jobs.
      */
     @DataBoundSetter
-    public void setCanResolveRelativePaths(boolean canResolveRelativePaths) {
+    public void setCanResolveRelativePaths(final boolean canResolveRelativePaths) {
         doNotResolveRelativePaths = !canResolveRelativePaths;
     }
 
@@ -701,17 +586,17 @@ public abstract class HealthAwareRecorder extends Recorder implements HealthDesc
      *  Useful when defining the groovy script in workflow jobs.
      */
     @DataBoundSetter
-    public void setCanComputeNew(boolean canComputeNew) {
+    public void setCanComputeNew(final boolean canComputeNew) {
         dontComputeNew = !canComputeNew;
     }
 
     @CheckForNull
     public String getUnstableTotalAll() {
-        return thresholds.unstableTotalHigh;
+        return thresholds.unstableTotalAll;
     }
 
     @DataBoundSetter
-    public void setUnstableTotalAll(String unstableTotalAll) {
+    public void setUnstableTotalAll(final String unstableTotalAll) {
         thresholds.unstableTotalAll = unstableTotalAll;
     }
 
@@ -721,7 +606,7 @@ public abstract class HealthAwareRecorder extends Recorder implements HealthDesc
     }
 
     @DataBoundSetter
-    public void setUnstableTotalHigh(String unstableTotalHigh) {
+    public void setUnstableTotalHigh(final String unstableTotalHigh) {
         thresholds.unstableTotalHigh = unstableTotalHigh;
     }
 
@@ -731,7 +616,7 @@ public abstract class HealthAwareRecorder extends Recorder implements HealthDesc
     }
 
     @DataBoundSetter
-    public void setUnstableTotalNormal(String unstableTotalNormal) {
+    public void setUnstableTotalNormal(final String unstableTotalNormal) {
         thresholds.unstableTotalNormal = unstableTotalNormal;
     }
 
@@ -741,7 +626,7 @@ public abstract class HealthAwareRecorder extends Recorder implements HealthDesc
     }
 
     @DataBoundSetter
-    public void setUnstableTotalLow(String unstableTotalLow) {
+    public void setUnstableTotalLow(final String unstableTotalLow) {
         thresholds.unstableTotalLow = unstableTotalLow;
     }
 
@@ -751,7 +636,7 @@ public abstract class HealthAwareRecorder extends Recorder implements HealthDesc
     }
 
     @DataBoundSetter
-    public void setUnstableNewAll(String unstableNewAll) {
+    public void setUnstableNewAll(final String unstableNewAll) {
         thresholds.unstableNewAll = unstableNewAll;
     }
 
@@ -761,7 +646,7 @@ public abstract class HealthAwareRecorder extends Recorder implements HealthDesc
     }
 
     @DataBoundSetter
-    public void setUnstableNewHigh(String unstableNewHigh) {
+    public void setUnstableNewHigh(final String unstableNewHigh) {
         thresholds.unstableNewHigh = unstableNewHigh;
     }
 
@@ -771,7 +656,7 @@ public abstract class HealthAwareRecorder extends Recorder implements HealthDesc
     }
 
     @DataBoundSetter
-    public void setUnstableNewNormal(String unstableNewNormal) {
+    public void setUnstableNewNormal(final String unstableNewNormal) {
         thresholds.unstableNewNormal = unstableNewNormal;
     }
 
@@ -781,7 +666,7 @@ public abstract class HealthAwareRecorder extends Recorder implements HealthDesc
     }
 
     @DataBoundSetter
-    public void setUnstableNewLow(String unstableNewLow) {
+    public void setUnstableNewLow(final String unstableNewLow) {
         thresholds.unstableNewLow = unstableNewLow;
     }
 
@@ -791,7 +676,7 @@ public abstract class HealthAwareRecorder extends Recorder implements HealthDesc
     }
 
     @DataBoundSetter
-    public void setFailedTotalAll(String failedTotalAll) {
+    public void setFailedTotalAll(final String failedTotalAll) {
         thresholds.failedTotalAll = failedTotalAll;
     }
 
@@ -801,7 +686,7 @@ public abstract class HealthAwareRecorder extends Recorder implements HealthDesc
     }
 
     @DataBoundSetter
-    public void setFailedTotalHigh(String failedTotalHigh) {
+    public void setFailedTotalHigh(final String failedTotalHigh) {
         thresholds.failedTotalHigh = failedTotalHigh;
     }
 
@@ -811,17 +696,17 @@ public abstract class HealthAwareRecorder extends Recorder implements HealthDesc
     }
 
     @DataBoundSetter
-    public void setFailedTotalNormal(String failedTotalNormal) {
+    public void setFailedTotalNormal(final String failedTotalNormal) {
         thresholds.failedTotalNormal = failedTotalNormal;
     }
 
     @CheckForNull
     public String getFailedTotalLow() {
-        return thresholds.failedTotalNormal;
+        return thresholds.failedTotalLow;
     }
 
     @DataBoundSetter
-    public void setFailedTotalLow(String failedTotalLow) {
+    public void setFailedTotalLow(final String failedTotalLow) {
         thresholds.failedTotalLow = failedTotalLow;
     }
 
@@ -831,7 +716,7 @@ public abstract class HealthAwareRecorder extends Recorder implements HealthDesc
     }
 
     @DataBoundSetter
-    public void setFailedNewAll(String failedNewAll) {
+    public void setFailedNewAll(final String failedNewAll) {
         thresholds.failedNewAll = failedNewAll;
     }
 
@@ -841,7 +726,7 @@ public abstract class HealthAwareRecorder extends Recorder implements HealthDesc
     }
 
     @DataBoundSetter
-    public void setFailedNewHigh(String failedNewHigh) {
+    public void setFailedNewHigh(final String failedNewHigh) {
         thresholds.failedNewHigh = failedNewHigh;
     }
 
@@ -851,7 +736,7 @@ public abstract class HealthAwareRecorder extends Recorder implements HealthDesc
     }
 
     @DataBoundSetter
-    public void setFailedNewNormal(String failedNewNormal) {
+    public void setFailedNewNormal(final String failedNewNormal) {
         thresholds.failedNewNormal = failedNewNormal;
     }
 
@@ -861,7 +746,7 @@ public abstract class HealthAwareRecorder extends Recorder implements HealthDesc
     }
 
     @DataBoundSetter
-    public void setFailedNewLow(String failedNewLow) {
+    public void setFailedNewLow(final String failedNewLow) {
         thresholds.failedNewLow = failedNewLow;
     }
 
@@ -983,5 +868,126 @@ public abstract class HealthAwareRecorder extends Recorder implements HealthDesc
                 failedNewAll, failedNewHigh, failedNewNormal, failedNewLow,
                 canRunOnFailed, false, shouldDetectModules, canComputeNew, canResolveRelativePaths, pluginName);
     }
+
+    /**
+     * Creates a new instance of {@link HealthAwareRecorder}.
+     *
+     * @param healthy
+     *            Report health as 100% when the number of open tasks is less
+     *            than this value
+     * @param unHealthy
+     *            Report health as 0% when the number of open tasks is greater
+     *            than this value
+     * @param thresholdLimit
+     *            determines which warning priorities should be considered when
+     *            evaluating the build stability and health
+     * @param defaultEncoding
+     *            the default encoding to be used when reading and parsing files
+     * @param useDeltaValues
+     *            determines whether the absolute annotations delta or the
+     *            actual annotations set difference should be used to evaluate
+     *            the build stability
+     * @param unstableTotalAll
+     *            annotation threshold
+     * @param unstableTotalHigh
+     *            annotation threshold
+     * @param unstableTotalNormal
+     *            annotation threshold
+     * @param unstableTotalLow
+     *            annotation threshold
+     * @param unstableNewAll
+     *            annotation threshold
+     * @param unstableNewHigh
+     *            annotation threshold
+     * @param unstableNewNormal
+     *            annotation threshold
+     * @param unstableNewLow
+     *            annotation threshold
+     * @param failedTotalAll
+     *            annotation threshold
+     * @param failedTotalHigh
+     *            annotation threshold
+     * @param failedTotalNormal
+     *            annotation threshold
+     * @param failedTotalLow
+     *            annotation threshold
+     * @param failedNewAll
+     *            annotation threshold
+     * @param failedNewHigh
+     *            annotation threshold
+     * @param failedNewNormal
+     *            annotation threshold
+     * @param failedNewLow
+     *            annotation threshold
+     * @param canRunOnFailed
+     *            determines whether the plug-in can run for failed builds, too
+     * @param usePreviousBuildAsReference
+     *            determine if the previous build should always be used as the
+     *            reference build, no matter its overall result.
+     * @param useStableBuildAsReference
+     *            determines whether only stable builds should be used as
+     *            reference builds or not
+     * @param shouldDetectModules
+     *            determines whether module names should be derived from Maven
+     *            POM or Ant build files
+     * @param canComputeNew
+     *            determines whether new warnings should be computed (with
+     *            respect to baseline)
+     * @param canResolveRelativePaths
+     *            determines whether relative paths in warnings should be
+     *            resolved using a time expensive operation that scans the whole
+     *            workspace for matching files.
+     * @param pluginName
+     *            the name of the plug-in
+     * @deprecated use setters instead
+     */
     // CHECKSTYLE:OFF
+    @SuppressWarnings("PMD")
+    @Deprecated
+    public HealthAwareRecorder(final String healthy, final String unHealthy,
+            final String thresholdLimit, final String defaultEncoding,
+            final boolean useDeltaValues, final String unstableTotalAll,
+            final String unstableTotalHigh, final String unstableTotalNormal,
+            final String unstableTotalLow, final String unstableNewAll,
+            final String unstableNewHigh, final String unstableNewNormal,
+            final String unstableNewLow, final String failedTotalAll, final String failedTotalHigh,
+            final String failedTotalNormal, final String failedTotalLow, final String failedNewAll,
+            final String failedNewHigh, final String failedNewNormal, final String failedNewLow,
+            final boolean canRunOnFailed, final boolean usePreviousBuildAsReference,
+            final boolean useStableBuildAsReference,
+            final boolean shouldDetectModules, final boolean canComputeNew,
+            final boolean canResolveRelativePaths, final String pluginName) {
+        super();
+        this.healthy = healthy;
+        this.unHealthy = unHealthy;
+        this.thresholdLimit = StringUtils.defaultIfEmpty(thresholdLimit, DEFAULT_PRIORITY_THRESHOLD_LIMIT);
+        this.defaultEncoding = defaultEncoding;
+        this.useDeltaValues = useDeltaValues;
+
+        doNotResolveRelativePaths = !canResolveRelativePaths;
+        dontComputeNew = !canComputeNew;
+
+        thresholds.unstableTotalAll = unstableTotalAll;
+        thresholds.unstableTotalHigh = unstableTotalHigh;
+        thresholds.unstableTotalNormal = unstableTotalNormal;
+        thresholds.unstableTotalLow = unstableTotalLow;
+        thresholds.unstableNewAll = unstableNewAll;
+        thresholds.unstableNewHigh = unstableNewHigh;
+        thresholds.unstableNewNormal = unstableNewNormal;
+        thresholds.unstableNewLow = unstableNewLow;
+        thresholds.failedTotalAll = failedTotalAll;
+        thresholds.failedTotalHigh = failedTotalHigh;
+        thresholds.failedTotalNormal = failedTotalNormal;
+        thresholds.failedTotalLow = failedTotalLow;
+        thresholds.failedNewAll = failedNewAll;
+        thresholds.failedNewHigh = failedNewHigh;
+        thresholds.failedNewNormal = failedNewNormal;
+        thresholds.failedNewLow = failedNewLow;
+
+        this.canRunOnFailed = canRunOnFailed;
+        this.usePreviousBuildAsReference = usePreviousBuildAsReference;
+        this.useStableBuildAsReference = useStableBuildAsReference;
+        this.shouldDetectModules = shouldDetectModules;
+        this.pluginName = "[" + pluginName + "] ";
+    }
 }

--- a/src/main/java/hudson/plugins/analysis/core/HealthAwareRecorder.java
+++ b/src/main/java/hudson/plugins/analysis/core/HealthAwareRecorder.java
@@ -626,9 +626,8 @@ public abstract class HealthAwareRecorder extends Recorder implements HealthDesc
      */
     @Deprecated
     protected boolean isMavenBuild(final AbstractBuild<?, ?> build) {
-        AbstractBuild aBuild = (AbstractBuild) build;
-        if (aBuild.getProject() instanceof Project) {
-            Project<?, ?> project = (Project<?, ?>) aBuild.getProject();
+        if (build.getProject() instanceof Project) {
+            Project<?, ?> project = (Project<?, ?>)build.getProject();
             for (Builder builder : project.getBuilders()) {
                 if (builder instanceof Maven) {
                     return true;

--- a/src/main/java/hudson/plugins/analysis/core/HealthAwareRecorder.java
+++ b/src/main/java/hudson/plugins/analysis/core/HealthAwareRecorder.java
@@ -610,7 +610,8 @@ public abstract class HealthAwareRecorder extends Recorder implements HealthDesc
     protected boolean isMavenBuild(final Run<?, ?> build) {
         if (build instanceof AbstractBuild) {
             return isMavenBuild((AbstractBuild) build);
-        } else {
+        }
+        else {
             return false;
         }
     }

--- a/src/main/java/hudson/plugins/analysis/core/HealthAwareReporter.java
+++ b/src/main/java/hudson/plugins/analysis/core/HealthAwareReporter.java
@@ -17,9 +17,11 @@ import hudson.maven.MavenBuildProxy.BuildCallable;
 import hudson.maven.MavenModuleSetBuild;
 import hudson.maven.MavenReporter;
 import hudson.maven.MojoInfo;
-import hudson.model.AbstractBuild;
+
+import hudson.model.Run;
 import hudson.model.BuildListener;
 import hudson.model.Result;
+
 import hudson.plugins.analysis.Messages;
 import hudson.plugins.analysis.util.EncodingValidator;
 import hudson.plugins.analysis.util.Files;
@@ -28,6 +30,7 @@ import hudson.plugins.analysis.util.PluginLogger;
 import hudson.plugins.analysis.util.StringPluginLogger;
 import hudson.plugins.analysis.util.model.FileAnnotation;
 import hudson.plugins.analysis.util.model.Priority;
+
 import hudson.remoting.VirtualChannel;
 import hudson.tasks.BuildStep;
 
@@ -394,7 +397,7 @@ public abstract class HealthAwareReporter<T extends BuildResult> extends MavenRe
         }
         mavenBuild.addAction(createMavenAggregatedReport(mavenBuild, buildResult));
         mavenBuild.registerAsProjectAction(HealthAwareReporter.this);
-        AbstractBuild<?, ?> referenceBuild = buildResult.getHistory().getReferenceBuild();
+        Run<?, ?> referenceBuild = buildResult.getHistory().getReferenceBuild();
         if (referenceBuild != null) {
             pluginLogger.log("Computing warning deltas based on reference build " + referenceBuild.getDisplayName());
         }

--- a/src/main/java/hudson/plugins/analysis/core/MavenResultAction.java
+++ b/src/main/java/hudson/plugins/analysis/core/MavenResultAction.java
@@ -1,6 +1,7 @@
 package hudson.plugins.analysis.core;
 
 import javax.annotation.CheckForNull;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
@@ -20,9 +21,11 @@ import hudson.maven.AggregatableAction;
 import hudson.maven.MavenAggregatedReport;
 import hudson.maven.MavenBuild;
 import hudson.maven.MavenModule;
-import hudson.model.AbstractBuild;
+
+import hudson.model.Run;
 import hudson.model.HealthReport;
 import hudson.model.Result;
+
 import hudson.plugins.analysis.util.PluginLogger;
 import hudson.plugins.analysis.util.StringPluginLogger;
 import hudson.plugins.analysis.util.ToolTipProvider;
@@ -279,7 +282,7 @@ public abstract class MavenResultAction<T extends BuildResult> implements Staple
      *
      * @return the associated build of this action
      */
-    public AbstractBuild<?, ?> getOwner() {
+    public Run<?, ?> getOwner() {
         return delegate.getOwner();
     }
 
@@ -298,7 +301,7 @@ public abstract class MavenResultAction<T extends BuildResult> implements Staple
     }
 
     @Override
-    public final AbstractBuild<?, ?> getBuild() {
+    public final Run<?, ?> getBuild() {
         return delegate.getBuild();
     }
 

--- a/src/main/java/hudson/plugins/analysis/core/MavenResultAction.java
+++ b/src/main/java/hudson/plugins/analysis/core/MavenResultAction.java
@@ -297,9 +297,8 @@ public abstract class MavenResultAction<T extends BuildResult> implements Staple
      * 
      * @see {@link WithBridgeMethods}
      */
-    @Restricted(NoExternalUse.class)
     @Deprecated
-    public final Object getAbstractBuild(Run owner, Class targetClass) {
+    private final Object getAbstractBuild(Run owner, Class targetClass) {
         return delegate.getOwner() instanceof AbstractBuild ? (AbstractBuild<?, ?>) delegate.getOwner() : null;
     }
 

--- a/src/main/java/hudson/plugins/analysis/core/MavenResultAction.java
+++ b/src/main/java/hudson/plugins/analysis/core/MavenResultAction.java
@@ -11,8 +11,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.apache.commons.lang.StringUtils;
-import org.kohsuke.accmod.Restricted;
-import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.StaplerProxy;
 
 import com.google.common.collect.Lists;
@@ -298,7 +296,7 @@ public abstract class MavenResultAction<T extends BuildResult> implements Staple
      * @see {@link WithBridgeMethods}
      */
     @Deprecated
-    private final Object getAbstractBuild(Run owner, Class targetClass) {
+    private Object getAbstractBuild(final Run owner, final Class targetClass) {
         return delegate.getOwner() instanceof AbstractBuild ? (AbstractBuild<?, ?>) delegate.getOwner() : null;
     }
 

--- a/src/main/java/hudson/plugins/analysis/core/MavenResultAction.java
+++ b/src/main/java/hudson/plugins/analysis/core/MavenResultAction.java
@@ -11,10 +11,13 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.apache.commons.lang.StringUtils;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.StaplerProxy;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import com.infradna.tool.bridge_method_injector.WithBridgeMethods;
 
 import hudson.FilePath;
 import hudson.maven.AggregatableAction;
@@ -22,6 +25,7 @@ import hudson.maven.MavenAggregatedReport;
 import hudson.maven.MavenBuild;
 import hudson.maven.MavenModule;
 
+import hudson.model.AbstractBuild;
 import hudson.model.Run;
 import hudson.model.HealthReport;
 import hudson.model.Result;
@@ -282,8 +286,21 @@ public abstract class MavenResultAction<T extends BuildResult> implements Staple
      *
      * @return the associated build of this action
      */
+    @WithBridgeMethods(value=AbstractBuild.class, adapterMethod="getAbstractBuild")
     public Run<?, ?> getOwner() {
         return delegate.getOwner();
+    }
+
+    /**
+     * Added for backward compatibility. It generates <pre>AbstractBuild getOwner()</pre> bytecode during the build
+     * process, so old implementations can use that signature.
+     * 
+     * @see {@link WithBridgeMethods}
+     */
+    @Restricted(NoExternalUse.class)
+    @Deprecated
+    public final Object getAbstractBuild(Run owner, Class targetClass) {
+        return delegate.getOwner() instanceof AbstractBuild ? (AbstractBuild<?, ?>) delegate.getOwner() : null;
     }
 
     /**
@@ -301,8 +318,9 @@ public abstract class MavenResultAction<T extends BuildResult> implements Staple
     }
 
     @Override
+    @WithBridgeMethods(value=AbstractBuild.class, adapterMethod="getAbstractBuild")
     public final Run<?, ?> getBuild() {
-        return delegate.getBuild();
+        return delegate.getOwner();
     }
 
     @Override

--- a/src/main/java/hudson/plugins/analysis/core/PluginDescriptor.java
+++ b/src/main/java/hudson/plugins/analysis/core/PluginDescriptor.java
@@ -7,7 +7,6 @@ import net.sf.json.JSONObject;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest;
 
 import hudson.FilePath;
 
@@ -31,7 +30,6 @@ public abstract class PluginDescriptor extends BuildStepDescriptor<Publisher> {
     /** Suffix of the URL of the plug-in result. */
     protected static final String RESULT_URL_SUFFIX = "Result";
     private static final String COMPUTE_NEW_SECTION_KEY = "canComputeNew";
-    private static final String CONFIGURATION_SECTION_KEY = "configuration"; // starting with 1.55
 
     /**
      * Returns the result URL for the specified plug-in.

--- a/src/main/java/hudson/plugins/analysis/core/PluginDescriptor.java
+++ b/src/main/java/hudson/plugins/analysis/core/PluginDescriptor.java
@@ -203,7 +203,8 @@ public abstract class PluginDescriptor extends BuildStepDescriptor<Publisher> {
             @QueryParameter final String pattern) throws IOException {
         if (project != null) {
             return FilePath.validateFileMask(project.getSomeWorkspace(), pattern);
-        } else {
+        }
+        else {
             // Workflow jobs have no workspace
             return FormValidation.ok();
         }

--- a/src/main/java/hudson/plugins/analysis/core/PluginDescriptor.java
+++ b/src/main/java/hudson/plugins/analysis/core/PluginDescriptor.java
@@ -212,7 +212,12 @@ public abstract class PluginDescriptor extends BuildStepDescriptor<Publisher> {
      */
     public FormValidation doCheckPattern(@AncestorInPath final AbstractProject<?, ?> project,
             @QueryParameter final String pattern) throws IOException {
-        return FilePath.validateFileMask(project.getSomeWorkspace(), pattern);
+        if (project != null) {
+            return FilePath.validateFileMask(project.getSomeWorkspace(), pattern);
+        } else {
+            // Workflow jobs does not have a workspace
+            return FormValidation.ok();
+        }
     }
 
     /**

--- a/src/main/java/hudson/plugins/analysis/core/PluginDescriptor.java
+++ b/src/main/java/hudson/plugins/analysis/core/PluginDescriptor.java
@@ -76,7 +76,10 @@ public abstract class PluginDescriptor extends BuildStepDescriptor<Publisher> {
      * @param hierarchical
      *            the JSON object containing a sub-section
      * @return the flat structure
+     *
+     * @deprecated This transformation is no longer required. The JSON is coming as expected from the browser.
      */
+    @Deprecated
     protected static JSONObject convertHierarchicalFormData(final JSONObject hierarchical) {
         return convertHierarchicalFormData(hierarchical, COMPUTE_NEW_SECTION_KEY);
     }
@@ -91,7 +94,10 @@ public abstract class PluginDescriptor extends BuildStepDescriptor<Publisher> {
      *            the section to flatten
      * @return the flat structure
      * @since 1.55
+     *
+     * @deprecated This transformation is no longer required. The JSON is coming as expected from the browser.
      */
+    @Deprecated
     @edu.umd.cs.findbugs.annotations.SuppressWarnings("WMI")
     protected static JSONObject convertHierarchicalFormData(final JSONObject hierarchical, final String section) {
         if (hierarchical.containsKey(section)) {

--- a/src/main/java/hudson/plugins/analysis/core/PluginDescriptor.java
+++ b/src/main/java/hudson/plugins/analysis/core/PluginDescriptor.java
@@ -204,7 +204,7 @@ public abstract class PluginDescriptor extends BuildStepDescriptor<Publisher> {
         if (project != null) {
             return FilePath.validateFileMask(project.getSomeWorkspace(), pattern);
         } else {
-            // Workflow jobs does not have a workspace
+            // Workflow jobs have no workspace
             return FormValidation.ok();
         }
     }

--- a/src/main/java/hudson/plugins/analysis/core/PluginDescriptor.java
+++ b/src/main/java/hudson/plugins/analysis/core/PluginDescriptor.java
@@ -122,21 +122,6 @@ public abstract class PluginDescriptor extends BuildStepDescriptor<Publisher> {
     }
 
     @Override
-    public Publisher newInstance(final StaplerRequest req, final JSONObject formData)
-            throws hudson.model.Descriptor.FormException {
-        JSONObject converted;
-        if (formData.containsKey(CONFIGURATION_SECTION_KEY)) {
-            JSONObject old = formData.getJSONObject(CONFIGURATION_SECTION_KEY);
-            formData.put(CONFIGURATION_SECTION_KEY, convertHierarchicalFormData(old));
-            converted = formData;
-        }
-        else {
-            converted = convertHierarchicalFormData(formData);
-        }
-        return super.newInstance(req, converted);
-    }
-
-    @Override
     public final String getHelpFile() {
         return getPluginRoot() + "help.html";
     }

--- a/src/main/java/hudson/plugins/analysis/core/ReporterDescriptor.java
+++ b/src/main/java/hudson/plugins/analysis/core/ReporterDescriptor.java
@@ -1,9 +1,6 @@
 package hudson.plugins.analysis.core;
 
-import net.sf.json.JSONObject;
-
 import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest;
 
 import hudson.maven.MavenReporter;
 import hudson.maven.MavenReporterDescriptor;
@@ -78,11 +75,5 @@ public abstract class ReporterDescriptor extends MavenReporterDescriptor {
      */
     public final FormValidation doCheckHeight(@QueryParameter final String height) {
         return publisherDescriptor.doCheckHeight(height);
-    }
-
-    @Override
-    public MavenReporter newInstance(final StaplerRequest req, final JSONObject formData)
-            throws hudson.model.Descriptor.FormException {
-        return super.newInstance(req, PluginDescriptor.convertHierarchicalFormData(formData));
     }
 }

--- a/src/main/java/hudson/plugins/analysis/core/ResultAction.java
+++ b/src/main/java/hudson/plugins/analysis/core/ResultAction.java
@@ -1,6 +1,6 @@
 package hudson.plugins.analysis.core;
 
-import hudson.model.AbstractBuild;
+import hudson.model.Run;
 import hudson.model.Action;
 import hudson.model.Result;
 
@@ -34,7 +34,7 @@ public interface ResultAction<T extends BuildResult> extends Action {
      *
      * @return the associated build of this action
      */
-    AbstractBuild<?, ?> getBuild();
+    Run<?, ?> getBuild();
 
     /**
      * Returns the associated tool tip provider.

--- a/src/main/java/hudson/plugins/analysis/graph/CategoryBuildResultGraph.java
+++ b/src/main/java/hudson/plugins/analysis/graph/CategoryBuildResultGraph.java
@@ -5,7 +5,6 @@ import java.awt.Color;
 import java.awt.Font;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -31,8 +30,6 @@ import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 
 import hudson.model.AbstractBuild;
-import hudson.model.ParameterValue;
-import hudson.model.ParametersAction;
 import hudson.model.Run;
 
 import hudson.plugins.analysis.core.ResultAction;

--- a/src/main/java/hudson/plugins/analysis/graph/CategoryBuildResultGraph.java
+++ b/src/main/java/hudson/plugins/analysis/graph/CategoryBuildResultGraph.java
@@ -253,7 +253,8 @@ public abstract class CategoryBuildResultGraph extends BuildResultGraph {
             // There is no comparable method for Run. This means that this feature (using parameters for
             // result graph) will not be available for other than AbstractBuild extending classes (basically
             // all except Workflow builds).
-            variables = null;
+            // So workflow jobs will be never filtered, just show them all.
+            return true;
         }
         if (variables == null) {
             return false;

--- a/src/main/java/hudson/plugins/analysis/graph/CategoryBuildResultGraph.java
+++ b/src/main/java/hudson/plugins/analysis/graph/CategoryBuildResultGraph.java
@@ -28,7 +28,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 
-import hudson.model.AbstractBuild;
+import hudson.model.Run;
 
 import hudson.plugins.analysis.core.ResultAction;
 import hudson.plugins.analysis.core.BuildResult;
@@ -202,12 +202,12 @@ public abstract class CategoryBuildResultGraph extends BuildResultGraph {
      * @return a series of values per build
      */
     @SuppressWarnings("rawtypes")
-    private Map<AbstractBuild, List<Integer>> createSeriesPerBuild(
+    private Map<Run, List<Integer>> createSeriesPerBuild(
             final GraphConfiguration configuration, final BuildResult lastBuildResult) {
         BuildResult current = lastBuildResult;
 
         int buildCount = 0;
-        Map<AbstractBuild, List<Integer>> valuesPerBuild = Maps.newHashMap();
+        Map<Run, List<Integer>> valuesPerBuild = Maps.newHashMap();
         while (true) {
             if (isBuildTooOld(configuration, current)) {
                 break;
@@ -243,11 +243,11 @@ public abstract class CategoryBuildResultGraph extends BuildResultGraph {
      * @return a data set
      */
     @SuppressWarnings({"rawtypes", "unchecked"})
-    private CategoryDataset createDatasetPerBuildNumber(final Map<AbstractBuild, List<Integer>> valuesPerBuild) {
+    private CategoryDataset createDatasetPerBuildNumber(final Map<Run, List<Integer>> valuesPerBuild) {
         DataSetBuilder<String, NumberOnlyBuildLabel> builder = new DataSetBuilder<String, NumberOnlyBuildLabel>();
-        List<AbstractBuild> builds = Lists.newArrayList(valuesPerBuild.keySet());
+        List<Run> builds = Lists.newArrayList(valuesPerBuild.keySet());
         Collections.sort(builds);
-        for (AbstractBuild<?, ?> build : builds) {
+        for (Run<?, ?> build : builds) {
             List<Integer> series = valuesPerBuild.get(build);
             int level = 0;
             for (Integer integer : series) {
@@ -290,7 +290,7 @@ public abstract class CategoryBuildResultGraph extends BuildResultGraph {
      */
     @SuppressWarnings("rawtypes")
     private Map<LocalDate, List<Integer>> averageByDate(
-            final Map<AbstractBuild, List<Integer>> valuesPerBuild) {
+            final Map<Run, List<Integer>> valuesPerBuild) {
         return createSeriesPerDay(createMultiSeriesPerDay(valuesPerBuild));
     }
 
@@ -340,9 +340,9 @@ public abstract class CategoryBuildResultGraph extends BuildResultGraph {
     @SuppressWarnings("rawtypes")
     @edu.umd.cs.findbugs.annotations.SuppressWarnings("WMI")
     private Multimap<LocalDate, List<Integer>> createMultiSeriesPerDay(
-            final Map<AbstractBuild, List<Integer>> valuesPerBuild) {
+            final Map<Run, List<Integer>> valuesPerBuild) {
         Multimap<LocalDate, List<Integer>> valuesPerDate = HashMultimap.create();
-        for (AbstractBuild<?, ?> build : valuesPerBuild.keySet()) {
+        for (Run<?, ?> build : valuesPerBuild.keySet()) {
             valuesPerDate.put(new LocalDate(build.getTimestamp()), valuesPerBuild.get(build));
         }
         return valuesPerDate;

--- a/src/main/java/hudson/plugins/analysis/util/Compatibility.java
+++ b/src/main/java/hudson/plugins/analysis/util/Compatibility.java
@@ -1,0 +1,44 @@
+package hudson.plugins.analysis.util;
+
+import java.lang.reflect.Method;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Compatibility utilities.
+ */
+public final class Compatibility {
+
+    /**
+     * Util.isOverriden does not work on non-public methods, that's why this one is used here.
+     */
+    public static boolean isOverridden(@Nonnull Class base, @Nonnull Class derived, @Nonnull String methodName, @Nonnull Class... types) {
+        try {
+            return !getMethod(base, methodName, types).equals(getMethod(derived, methodName, types));
+        } catch (NoSuchMethodException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    private static Method getMethod(@Nonnull Class clazz, @Nonnull String methodName, @Nonnull Class... types) throws NoSuchMethodException {
+        Method res = null;
+        try {
+            res = clazz.getDeclaredMethod(methodName, types);
+        } catch (NoSuchMethodException e) {
+            // Method not found in clazz, let's search in superclasses
+            Class superclass = clazz.getSuperclass();
+            if (superclass != null) {
+                res = getMethod(superclass, methodName, types);
+            }
+        } catch (SecurityException e) {
+            throw new AssertionError(e);
+        }
+        if (res == null) {
+            throw new NoSuchMethodException("Method " + methodName + " not found in " + clazz.getName());
+        }
+        return res;
+    }
+
+    private Compatibility() {}
+}
+

--- a/src/main/java/hudson/plugins/analysis/util/FileFinder.java
+++ b/src/main/java/hudson/plugins/analysis/util/FileFinder.java
@@ -3,12 +3,12 @@ package hudson.plugins.analysis.util;
 import java.io.File;
 import java.io.IOException;
 
+import jenkins.MasterToSlaveFileCallable;
+
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.types.FileSet;
-import org.jenkinsci.remoting.RoleChecker;
 
-import hudson.FilePath.FileCallable;
 import hudson.remoting.VirtualChannel;
 
 /**
@@ -16,7 +16,7 @@ import hudson.remoting.VirtualChannel;
  *
  * @author Ulli Hafner
  */
-public class FileFinder implements FileCallable<String[]> {
+public class FileFinder extends MasterToSlaveFileCallable<String[]> {
     /** Generated ID. */
     private static final long serialVersionUID = 2970029366847565970L;
     /** File name pattern for java files. */
@@ -80,10 +80,5 @@ public class FileFinder implements FileCallable<String[]> {
         catch (BuildException exception) {
             return new String[0];
         }
-    }
-
-    @Override
-    public void checkRoles(RoleChecker checker) throws SecurityException {
-        // TODO required in 1.580 (do we need to implement something here?)
     }
 }

--- a/src/main/java/hudson/plugins/analysis/util/FileFinder.java
+++ b/src/main/java/hudson/plugins/analysis/util/FileFinder.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.types.FileSet;
+import org.jenkinsci.remoting.RoleChecker;
 
 import hudson.FilePath.FileCallable;
 import hudson.remoting.VirtualChannel;
@@ -79,5 +80,10 @@ public class FileFinder implements FileCallable<String[]> {
         catch (BuildException exception) {
             return new String[0];
         }
+    }
+
+    @Override
+    public void checkRoles(RoleChecker checker) throws SecurityException {
+        // TODO required in 1.580 (do we need to implement something here?)
     }
 }

--- a/src/main/java/hudson/plugins/analysis/util/model/AbstractAnnotation.java
+++ b/src/main/java/hudson/plugins/analysis/util/model/AbstractAnnotation.java
@@ -581,7 +581,7 @@ public abstract class AbstractAnnotation implements FileAnnotation, Serializable
      * @return <code>true</code>, if successful
      */
     @Override
-    public final boolean canDisplayFile(final AbstractBuild<?, ?> owner) {
+    public final boolean canDisplayFile(final Run<?, ?> owner) {
         if (owner.hasPermission(Item.WORKSPACE)) {
             return isInConsoleLog() || new File(getFileName()).exists() || new File(getTempName(owner)).exists();
         }

--- a/src/main/java/hudson/plugins/analysis/util/model/AbstractAnnotation.java
+++ b/src/main/java/hudson/plugins/analysis/util/model/AbstractAnnotation.java
@@ -5,6 +5,8 @@ import java.io.Serializable;
 import java.util.Collection;
 import java.util.Collections;
 
+import javax.annotation.Nonnull;
+
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.kohsuke.stapler.export.Exported;
@@ -352,7 +354,7 @@ public abstract class AbstractAnnotation implements FileAnnotation, Serializable
     }
 
     @Override
-    public String getTempName(final Run<?, ?> owner) {
+    public String getTempName(@Nonnull final Run<?, ?> owner) {
         if (fileName != null) {
             return owner.getRootDir().getAbsolutePath()
                     + SLASH + WORKSPACE_FILES

--- a/src/main/java/hudson/plugins/analysis/util/model/AbstractAnnotation.java
+++ b/src/main/java/hudson/plugins/analysis/util/model/AbstractAnnotation.java
@@ -13,7 +13,9 @@ import org.kohsuke.stapler.export.ExportedBean;
 import com.google.common.collect.ImmutableList;
 
 import hudson.model.AbstractBuild;
+import hudson.model.Run;
 import hudson.model.Item;
+
 import hudson.plugins.analysis.Messages;
 import hudson.plugins.analysis.core.AbstractAnnotationParser;
 import hudson.plugins.analysis.util.PackageDetectors;
@@ -350,7 +352,7 @@ public abstract class AbstractAnnotation implements FileAnnotation, Serializable
     }
 
     @Override
-    public String getTempName(final AbstractBuild<?, ?> owner) {
+    public String getTempName(final Run<?, ?> owner) {
         if (fileName != null) {
             return owner.getRootDir().getAbsolutePath()
                     + SLASH + WORKSPACE_FILES

--- a/src/main/java/hudson/plugins/analysis/util/model/AbstractAnnotation.java
+++ b/src/main/java/hudson/plugins/analysis/util/model/AbstractAnnotation.java
@@ -625,4 +625,12 @@ public abstract class AbstractAnnotation implements FileAnnotation, Serializable
     public int getBuild() {
         return build;
     }
+
+    /**
+     * @deprecated use {@link #getTempName(Run)} instead
+     */
+    @Deprecated
+    public String getTempName(final AbstractBuild<?, ?> owner) {
+        return getTempName((Run<?, ?>) owner);
+    }
 }

--- a/src/main/java/hudson/plugins/analysis/util/model/FileAnnotation.java
+++ b/src/main/java/hudson/plugins/analysis/util/model/FileAnnotation.java
@@ -3,6 +3,7 @@ package hudson.plugins.analysis.util.model;
 import java.util.Collection;
 
 import hudson.model.AbstractBuild;
+import hudson.model.Run;
 
 /**
  * Annotates a collection of line ranges in a file. An annotation consists of a description and a tooltip.
@@ -74,7 +75,7 @@ public interface FileAnnotation extends Comparable<FileAnnotation> {
      * @param owner the owner that provides the root directory where the files are stored
      * @return the temporary name
      */
-    String getTempName(AbstractBuild<?, ?> owner);
+    String getTempName(Run<?, ?> owner);
 
     /**
      * Sets the file name to the specified value.

--- a/src/main/java/hudson/plugins/analysis/util/model/FileAnnotation.java
+++ b/src/main/java/hudson/plugins/analysis/util/model/FileAnnotation.java
@@ -97,7 +97,7 @@ public interface FileAnnotation extends Comparable<FileAnnotation> {
      * @param owner the owner that provides the root directory where the files are stored
      * @return <code>true</code>, if successful
      */
-    boolean canDisplayFile(AbstractBuild<?, ?> owner);
+    boolean canDisplayFile(Run<?, ?> owner);
 
     /**
      * Gets the associated file name of this bug (without path).

--- a/src/main/java/hudson/plugins/analysis/views/AbstractAnnotationsDetail.java
+++ b/src/main/java/hudson/plugins/analysis/views/AbstractAnnotationsDetail.java
@@ -94,9 +94,8 @@ public abstract class AbstractAnnotationsDetail extends AnnotationContainer impl
      * 
      * @see {@link WithBridgeMethods}
      */
-    @Restricted(NoExternalUse.class)
     @Deprecated
-    public final Object getAbstractBuild(Run owner, Class targetClass) {
+    private final Object getAbstractBuild(Run owner, Class targetClass) {
       return owner instanceof AbstractBuild ? (AbstractBuild) owner : null;
     }
 
@@ -169,11 +168,6 @@ public abstract class AbstractAnnotationsDetail extends AnnotationContainer impl
      */
     @Deprecated
     public AbstractAnnotationsDetail(final AbstractBuild<?, ?> owner, final DetailFactory detailFactory, final Collection<FileAnnotation> annotations, final String defaultEncoding, final String name, final Hierarchy hierarchy) {
-        super(name, hierarchy);
-        this.owner = owner;
-        this.detailFactory = detailFactory;
-        this.defaultEncoding = defaultEncoding;
-
-        addAnnotations(annotations);
+        this((Run<?, ?>) owner, detailFactory, annotations, defaultEncoding, name, hierarchy);
     }
 }

--- a/src/main/java/hudson/plugins/analysis/views/AbstractAnnotationsDetail.java
+++ b/src/main/java/hudson/plugins/analysis/views/AbstractAnnotationsDetail.java
@@ -6,6 +6,7 @@ import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 
 import hudson.model.ModelObject;
+import hudson.model.AbstractBuild;
 import hudson.model.Run;
 
 import hudson.plugins.analysis.util.model.AnnotationContainer;
@@ -130,5 +131,32 @@ public abstract class AbstractAnnotationsDetail extends AnnotationContainer impl
      */
     public Priority[] getPriorities() {
         return Priority.values();
+    }
+
+    /**
+     * Creates a new instance of {@link AbstractAnnotationsDetail}.
+     *
+     * @param owner
+     *            current build as owner of this object
+     * @param detailFactory
+     *            factory to create detail objects with
+     * @param annotations
+     *            the set of warnings represented by this object
+     * @param defaultEncoding
+     *            the default encoding to be used when reading and parsing files
+     * @param name
+     *            the name of this object
+     * @param hierarchy
+     *            the hierarchy level of this detail object
+     * @deprecated use {@link #AbstractAnnotationsDetail(Run, DetailFactory, Collection, String, String, Hierarchy)} instead
+     */
+    @Deprecated
+    public AbstractAnnotationsDetail(final AbstractBuild<?, ?> owner, final DetailFactory detailFactory, final Collection<FileAnnotation> annotations, final String defaultEncoding, final String name, final Hierarchy hierarchy) {
+        super(name, hierarchy);
+        this.owner = owner;
+        this.detailFactory = detailFactory;
+        this.defaultEncoding = defaultEncoding;
+
+        addAnnotations(annotations);
     }
 }

--- a/src/main/java/hudson/plugins/analysis/views/AbstractAnnotationsDetail.java
+++ b/src/main/java/hudson/plugins/analysis/views/AbstractAnnotationsDetail.java
@@ -6,7 +6,7 @@ import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 
 import hudson.model.ModelObject;
-import hudson.model.AbstractBuild;
+import hudson.model.Run;
 
 import hudson.plugins.analysis.util.model.AnnotationContainer;
 import hudson.plugins.analysis.util.model.FileAnnotation;
@@ -23,7 +23,7 @@ public abstract class AbstractAnnotationsDetail extends AnnotationContainer impl
     private static final long serialVersionUID = 1750266351592937774L;
 
     /** Current build as owner of this object. */
-    private final AbstractBuild<?, ?> owner;
+    private final Run<?, ?> owner;
     /** The default encoding to be used when reading and parsing files. */
     private final String defaultEncoding;
 
@@ -46,7 +46,7 @@ public abstract class AbstractAnnotationsDetail extends AnnotationContainer impl
      * @param hierarchy
      *            the hierarchy level of this detail object
      */
-    public AbstractAnnotationsDetail(final AbstractBuild<?, ?> owner, final DetailFactory detailFactory, final Collection<FileAnnotation> annotations, final String defaultEncoding, final String name, final Hierarchy hierarchy) {
+    public AbstractAnnotationsDetail(final Run<?, ?> owner, final DetailFactory detailFactory, final Collection<FileAnnotation> annotations, final String defaultEncoding, final String name, final Hierarchy hierarchy) {
         super(name, hierarchy);
         this.owner = owner;
         this.detailFactory = detailFactory;
@@ -78,7 +78,7 @@ public abstract class AbstractAnnotationsDetail extends AnnotationContainer impl
      *
      * @return the owner
      */
-    public final AbstractBuild<?, ?> getOwner() {
+    public final Run<?, ?> getOwner() {
         return owner;
     }
 
@@ -88,7 +88,7 @@ public abstract class AbstractAnnotationsDetail extends AnnotationContainer impl
      * @return <code>true</code> if this build is the last available build
      */
     public final boolean isCurrent() {
-        return owner.getProject().getLastBuild().number == owner.number;
+        return owner.getParent().getLastBuild().number == owner.number;
     }
 
     /**

--- a/src/main/java/hudson/plugins/analysis/views/AbstractAnnotationsDetail.java
+++ b/src/main/java/hudson/plugins/analysis/views/AbstractAnnotationsDetail.java
@@ -2,8 +2,12 @@ package hudson.plugins.analysis.views;
 
 import java.util.Collection;
 
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
+
+import com.infradna.tool.bridge_method_injector.WithBridgeMethods;
 
 import hudson.model.ModelObject;
 import hudson.model.AbstractBuild;
@@ -79,8 +83,21 @@ public abstract class AbstractAnnotationsDetail extends AnnotationContainer impl
      *
      * @return the owner
      */
+    @WithBridgeMethods(value=AbstractBuild.class, adapterMethod="getAbstractBuild")
     public final Run<?, ?> getOwner() {
         return owner;
+    }
+
+    /**
+     * Added for backward compatibility. It generates <pre>AbstractBuild getOwner()</pre> bytecode during the build
+     * process, so old implementations can use that signature.
+     * 
+     * @see {@link WithBridgeMethods}
+     */
+    @Restricted(NoExternalUse.class)
+    @Deprecated
+    public final Object getAbstractBuild(Run owner, Class targetClass) {
+      return owner instanceof AbstractBuild ? (AbstractBuild) owner : null;
     }
 
     /**

--- a/src/main/java/hudson/plugins/analysis/views/AttributeDetail.java
+++ b/src/main/java/hudson/plugins/analysis/views/AttributeDetail.java
@@ -2,6 +2,7 @@ package hudson.plugins.analysis.views;
 
 import java.util.Collection;
 
+import hudson.model.AbstractBuild;
 import hudson.model.Run;
 
 import hudson.plugins.analysis.util.model.FileAnnotation;
@@ -41,6 +42,29 @@ public class AttributeDetail extends AbstractAnnotationsDetail {
     @Override
     public String getDisplayName() {
         return attributeName;
+    }
+
+    /**
+     * Creates a new instance of {@link AttributeDetail}.
+     *
+     * @param owner
+     *            current build as owner of this action.
+     * @param detailFactory
+     *            factory to create detail objects with
+     * @param annotations
+     *            the module to show the details for
+     * @param header
+     *            header to be shown on detail page
+     * @param defaultEncoding
+     *            the default encoding to be used when reading and parsing files
+     * @param name
+     *            name of the attribute shown in the bread crumb
+     * @deprecated use {@link #AttributeDetail(Run, DetailFactory, Collection, String, String, String)} instead
+     */
+    @Deprecated
+    public AttributeDetail(final AbstractBuild<?, ?> owner, final DetailFactory detailFactory, final Collection<FileAnnotation> annotations, final String defaultEncoding, final String header, final String name) {
+        super(owner, detailFactory, annotations, defaultEncoding, header, Hierarchy.PROJECT);
+        attributeName = name;
     }
 }
 

--- a/src/main/java/hudson/plugins/analysis/views/AttributeDetail.java
+++ b/src/main/java/hudson/plugins/analysis/views/AttributeDetail.java
@@ -63,8 +63,7 @@ public class AttributeDetail extends AbstractAnnotationsDetail {
      */
     @Deprecated
     public AttributeDetail(final AbstractBuild<?, ?> owner, final DetailFactory detailFactory, final Collection<FileAnnotation> annotations, final String defaultEncoding, final String header, final String name) {
-        super(owner, detailFactory, annotations, defaultEncoding, header, Hierarchy.PROJECT);
-        attributeName = name;
+        this((Run<?, ?>) owner, detailFactory, annotations, defaultEncoding, header, name);
     }
 }
 

--- a/src/main/java/hudson/plugins/analysis/views/AttributeDetail.java
+++ b/src/main/java/hudson/plugins/analysis/views/AttributeDetail.java
@@ -2,7 +2,7 @@ package hudson.plugins.analysis.views;
 
 import java.util.Collection;
 
-import hudson.model.AbstractBuild;
+import hudson.model.Run;
 
 import hudson.plugins.analysis.util.model.FileAnnotation;
 
@@ -33,7 +33,7 @@ public class AttributeDetail extends AbstractAnnotationsDetail {
      * @param name
      *            name of the attribute shown in the bread crumb
      */
-    public AttributeDetail(final AbstractBuild<?, ?> owner, final DetailFactory detailFactory, final Collection<FileAnnotation> annotations, final String defaultEncoding, final String header, final String name) {
+    public AttributeDetail(final Run<?, ?> owner, final DetailFactory detailFactory, final Collection<FileAnnotation> annotations, final String defaultEncoding, final String header, final String name) {
         super(owner, detailFactory, annotations, defaultEncoding, header, Hierarchy.PROJECT);
         attributeName = name;
     }

--- a/src/main/java/hudson/plugins/analysis/views/ConsoleDetail.java
+++ b/src/main/java/hudson/plugins/analysis/views/ConsoleDetail.java
@@ -12,6 +12,7 @@ import org.apache.commons.lang.StringUtils;
 import hudson.console.ConsoleNote;
 
 import hudson.model.ModelObject;
+import hudson.model.AbstractBuild;
 import hudson.model.Run;
 
 import hudson.plugins.analysis.Messages;
@@ -117,5 +118,28 @@ public class ConsoleDetail implements ModelObject {
      */
     public String getSourceCode() {
         return sourceCode;
+    }
+
+    /**
+     * Creates a new instance of this console log viewer object.
+     *
+     * @param owner
+     *            the current build as owner of this object
+     * @param from
+     *            first line in the console log
+     * @param to
+     *            last line in the console log
+     * @deprecated use {@link #ConsoleDetail(Run, int, int)} instead
+     */
+    @Deprecated
+    public ConsoleDetail(final AbstractBuild<?, ?> owner, final int from, final int to) {
+        this.owner = owner;
+        this.from = from;
+        this.to = to;
+
+        start = Math.max(0, from - 10);
+        end = to + 10;
+
+        readConsole();
     }
 }

--- a/src/main/java/hudson/plugins/analysis/views/ConsoleDetail.java
+++ b/src/main/java/hudson/plugins/analysis/views/ConsoleDetail.java
@@ -12,7 +12,7 @@ import org.apache.commons.lang.StringUtils;
 import hudson.console.ConsoleNote;
 
 import hudson.model.ModelObject;
-import hudson.model.AbstractBuild;
+import hudson.model.Run;
 
 import hudson.plugins.analysis.Messages;
 
@@ -26,7 +26,7 @@ public class ConsoleDetail implements ModelObject {
     /** Filename dummy if the console log is the source of the warning. */
     public static final String CONSOLE_LOG_FILENAME = "Console Log";
     /** The current build as owner of this object. */
-    private final AbstractBuild<?, ?> owner;
+    private final Run<?, ?> owner;
     /** The rendered source file. */
     private String sourceCode = StringUtils.EMPTY;
     private final int from;
@@ -44,7 +44,7 @@ public class ConsoleDetail implements ModelObject {
      * @param to
      *            last line in the console log
      */
-    public ConsoleDetail(final AbstractBuild<?, ?> owner, final int from, final int to) {
+    public ConsoleDetail(final Run<?, ?> owner, final int from, final int to) {
         this.owner = owner;
         this.from = from;
         this.to = to;
@@ -106,7 +106,7 @@ public class ConsoleDetail implements ModelObject {
      *
      * @return the build
      */
-    public AbstractBuild<?, ?> getOwner() {
+    public Run<?, ?> getOwner() {
         return owner;
     }
 

--- a/src/main/java/hudson/plugins/analysis/views/ConsoleDetail.java
+++ b/src/main/java/hudson/plugins/analysis/views/ConsoleDetail.java
@@ -122,9 +122,8 @@ public class ConsoleDetail implements ModelObject {
      * 
      * @see {@link WithBridgeMethods}
      */
-    @Restricted(NoExternalUse.class)
     @Deprecated
-    public final Object getAbstractBuild(Run owner, Class targetClass) {
+    private final Object getAbstractBuild(Run owner, Class targetClass) {
       return owner instanceof AbstractBuild ? (AbstractBuild) owner : null;
     }
 
@@ -150,13 +149,6 @@ public class ConsoleDetail implements ModelObject {
      */
     @Deprecated
     public ConsoleDetail(final AbstractBuild<?, ?> owner, final int from, final int to) {
-        this.owner = owner;
-        this.from = from;
-        this.to = to;
-
-        start = Math.max(0, from - 10);
-        end = to + 10;
-
-        readConsole();
+        this((Run<?, ?>) owner, from ,to);
     }
 }

--- a/src/main/java/hudson/plugins/analysis/views/ConsoleDetail.java
+++ b/src/main/java/hudson/plugins/analysis/views/ConsoleDetail.java
@@ -8,6 +8,10 @@ import java.io.InputStreamReader;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang.StringUtils;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+import com.infradna.tool.bridge_method_injector.WithBridgeMethods;
 
 import hudson.console.ConsoleNote;
 
@@ -107,8 +111,21 @@ public class ConsoleDetail implements ModelObject {
      *
      * @return the build
      */
+    @WithBridgeMethods(value=AbstractBuild.class, adapterMethod="getAbstractBuild")
     public Run<?, ?> getOwner() {
         return owner;
+    }
+
+    /**
+     * Added for backward compatibility. It generates <pre>AbstractBuild getOwner()</pre> bytecode during the build
+     * process, so old implementations can use that signature.
+     * 
+     * @see {@link WithBridgeMethods}
+     */
+    @Restricted(NoExternalUse.class)
+    @Deprecated
+    public final Object getAbstractBuild(Run owner, Class targetClass) {
+      return owner instanceof AbstractBuild ? (AbstractBuild) owner : null;
     }
 
     /**

--- a/src/main/java/hudson/plugins/analysis/views/DetailFactory.java
+++ b/src/main/java/hudson/plugins/analysis/views/DetailFactory.java
@@ -9,6 +9,7 @@ import com.google.common.collect.Maps;
 
 import hudson.model.Item;
 import hudson.model.AbstractBuild;
+import hudson.model.Run;
 
 import hudson.plugins.analysis.Messages;
 import hudson.plugins.analysis.core.ResultAction;
@@ -85,7 +86,7 @@ public class DetailFactory {
      * @return the dynamic result of this module detail view
      */
     // CHECKSTYLE:OFF
-    public Object createTrendDetails(final String link, final AbstractBuild<?, ?> owner,
+    public Object createTrendDetails(final String link, final Run<?, ?> owner,
             final AnnotationContainer container, final Collection<FileAnnotation> fixedAnnotations,
             final Collection<FileAnnotation> newAnnotations, final Collection<String> errors,
             final String defaultEncoding, final String displayName) {
@@ -139,7 +140,7 @@ public class DetailFactory {
      *            the name of the selected object
      * @return the dynamic result of this module detail view
      */
-    public Object createDetails(final String link, final AbstractBuild<?, ?> owner, final AnnotationContainer container,
+    public Object createDetails(final String link, final Run<?, ?> owner, final AnnotationContainer container,
             final String defaultEncoding, final String displayName) {
         PriorityDetailFactory factory = new PriorityDetailFactory(this);
         AnnotationContainer detail = null;
@@ -199,7 +200,7 @@ public class DetailFactory {
      *            the default encoding to be used when reading and parsing files
      * @return the detail view
      */
-    protected AttributeDetail createAttributeDetail(final AbstractBuild<?, ?> owner, final DefaultAnnotationContainer annotations,
+    protected AttributeDetail createAttributeDetail(final Run<?, ?> owner, final DefaultAnnotationContainer annotations,
             final String displayName, final String header, final String defaultEncoding) {
         return new AttributeDetail(owner, this, annotations.getAnnotations(), defaultEncoding, displayName, header + " " + annotations.getName());
     }
@@ -217,7 +218,7 @@ public class DetailFactory {
      *            the default encoding to be used when reading and parsing files
      * @return the detail view
      */
-    protected TabDetail createTabDetail(final AbstractBuild<?, ?> owner, final Collection<FileAnnotation> annotations,
+    protected TabDetail createTabDetail(final Run<?, ?> owner, final Collection<FileAnnotation> annotations,
             final String url, final String defaultEncoding) {
         return new TabDetail(owner, this, annotations, url, defaultEncoding);
     }
@@ -235,7 +236,7 @@ public class DetailFactory {
      *            the name of the view
      * @return the detail view
      */
-    protected FixedWarningsDetail createFixedWarningsDetail(final AbstractBuild<?, ?> owner,
+    protected FixedWarningsDetail createFixedWarningsDetail(final Run<?, ?> owner,
             final Collection<FileAnnotation> fixedAnnotations, final String defaultEncoding,
             final String displayName) {
         return new FixedWarningsDetail(owner, this, fixedAnnotations, defaultEncoding, displayName);

--- a/src/main/java/hudson/plugins/analysis/views/DetailFactory.java
+++ b/src/main/java/hudson/plugins/analysis/views/DetailFactory.java
@@ -218,7 +218,7 @@ public class DetailFactory {
     protected AttributeDetail createAttributeDetail(@Nonnull final Run<?, ?> owner, final DefaultAnnotationContainer annotations,
             final String displayName, final String header, final String defaultEncoding) {
         if (owner instanceof AbstractBuild && Compatibility.isOverridden(DetailFactory.class, getClass(),
-                "createAttributeDetail", AbstractBuild.class, DefaultAnnotationContainer.class, String.class, String.class, String.class, String.class)) {
+                "createAttributeDetail", AbstractBuild.class, DefaultAnnotationContainer.class, String.class, String.class, String.class)) {
             return createAttributeDetail((AbstractBuild<?, ?>) owner, annotations, displayName, header, defaultEncoding);
         }
         else {

--- a/src/main/java/hudson/plugins/analysis/views/DetailFactory.java
+++ b/src/main/java/hudson/plugins/analysis/views/DetailFactory.java
@@ -264,5 +264,45 @@ public class DetailFactory {
     private int createHashCode(final String link, final String prefix) {
         return Integer.parseInt(StringUtils.substringAfter(link, prefix));
     }
-}
 
+    /**
+     * Creates a generic detail tab with the specified link.
+     *
+     * @param owner
+     *            the build as owner of the detail page
+     * @param annotations
+     *            the annotations to display
+     * @param url
+     *            the URL for the details view
+     * @param defaultEncoding
+     *            the default encoding to be used when reading and parsing files
+     * @return the detail view
+     * @deprecated use {@link #createTabDetail(Run, Collection, String, String)} instead
+     */
+    @Deprecated
+    protected TabDetail createTabDetail(final AbstractBuild<?, ?> owner, final Collection<FileAnnotation> annotations,
+            final String url, final String defaultEncoding) {
+        return new TabDetail(owner, this, annotations, url, defaultEncoding);
+    }
+
+    /**
+     * Creates a generic fixed warnings detail tab with the specified link.
+     *
+     * @param owner
+     *            the build as owner of the detail page
+     * @param fixedAnnotations
+     *            the annotations to display
+     * @param defaultEncoding
+     *            the default encoding to be used when reading and parsing files
+     * @param displayName
+     *            the name of the view
+     * @return the detail view
+     * @deprecated use {@link #createFixedWarningsDetail(Run, Collection, String, String)} instead
+     */
+    @Deprecated
+    protected FixedWarningsDetail createFixedWarningsDetail(final AbstractBuild<?, ?> owner,
+            final Collection<FileAnnotation> fixedAnnotations, final String defaultEncoding,
+            final String displayName) {
+        return new FixedWarningsDetail(owner, this, fixedAnnotations, defaultEncoding, displayName);
+    }
+}

--- a/src/main/java/hudson/plugins/analysis/views/DetailFactory.java
+++ b/src/main/java/hudson/plugins/analysis/views/DetailFactory.java
@@ -3,6 +3,8 @@ package hudson.plugins.analysis.views;
 import java.util.Collection;
 import java.util.Map;
 
+import javax.annotation.Nonnull;
+
 import org.apache.commons.lang.StringUtils;
 
 import com.google.common.collect.Maps;
@@ -86,7 +88,7 @@ public class DetailFactory {
      * @return the dynamic result of this module detail view
      */
     // CHECKSTYLE:OFF
-    public Object createTrendDetails(final String link, final Run<?, ?> owner,
+    public Object createTrendDetails(final String link, @Nonnull final Run<?, ?> owner,
             final AnnotationContainer container, final Collection<FileAnnotation> fixedAnnotations,
             final Collection<FileAnnotation> newAnnotations, final Collection<String> errors,
             final String defaultEncoding, final String displayName) {
@@ -140,7 +142,7 @@ public class DetailFactory {
      *            the name of the selected object
      * @return the dynamic result of this module detail view
      */
-    public Object createDetails(final String link, final Run<?, ?> owner, final AnnotationContainer container,
+    public Object createDetails(final String link, @Nonnull final Run<?, ?> owner, final AnnotationContainer container,
             final String defaultEncoding, final String displayName) {
         PriorityDetailFactory factory = new PriorityDetailFactory(this);
         AnnotationContainer detail = null;
@@ -200,7 +202,7 @@ public class DetailFactory {
      *            the default encoding to be used when reading and parsing files
      * @return the detail view
      */
-    protected AttributeDetail createAttributeDetail(final Run<?, ?> owner, final DefaultAnnotationContainer annotations,
+    protected AttributeDetail createAttributeDetail(@Nonnull final Run<?, ?> owner, final DefaultAnnotationContainer annotations,
             final String displayName, final String header, final String defaultEncoding) {
         return new AttributeDetail(owner, this, annotations.getAnnotations(), defaultEncoding, displayName, header + " " + annotations.getName());
     }
@@ -218,7 +220,7 @@ public class DetailFactory {
      *            the default encoding to be used when reading and parsing files
      * @return the detail view
      */
-    protected TabDetail createTabDetail(final Run<?, ?> owner, final Collection<FileAnnotation> annotations,
+    protected TabDetail createTabDetail(@Nonnull final Run<?, ?> owner, final Collection<FileAnnotation> annotations,
             final String url, final String defaultEncoding) {
         return new TabDetail(owner, this, annotations, url, defaultEncoding);
     }
@@ -236,7 +238,7 @@ public class DetailFactory {
      *            the name of the view
      * @return the detail view
      */
-    protected FixedWarningsDetail createFixedWarningsDetail(final Run<?, ?> owner,
+    protected FixedWarningsDetail createFixedWarningsDetail(@Nonnull final Run<?, ?> owner,
             final Collection<FileAnnotation> fixedAnnotations, final String defaultEncoding,
             final String displayName) {
         return new FixedWarningsDetail(owner, this, fixedAnnotations, defaultEncoding, displayName);

--- a/src/main/java/hudson/plugins/analysis/views/DetailFactory.java
+++ b/src/main/java/hudson/plugins/analysis/views/DetailFactory.java
@@ -282,7 +282,7 @@ public class DetailFactory {
     @Deprecated
     protected TabDetail createTabDetail(final AbstractBuild<?, ?> owner, final Collection<FileAnnotation> annotations,
             final String url, final String defaultEncoding) {
-        return new TabDetail(owner, this, annotations, url, defaultEncoding);
+        return createTabDetail((Run<?, ?>) owner, annotations, url, defaultEncoding);
     }
 
     /**
@@ -303,6 +303,35 @@ public class DetailFactory {
     protected FixedWarningsDetail createFixedWarningsDetail(final AbstractBuild<?, ?> owner,
             final Collection<FileAnnotation> fixedAnnotations, final String defaultEncoding,
             final String displayName) {
-        return new FixedWarningsDetail(owner, this, fixedAnnotations, defaultEncoding, displayName);
+        return createFixedWarningsDetail((Run<?, ?>) owner, fixedAnnotations, defaultEncoding, displayName);
+    }
+
+    /**
+     * @deprecated use {@link #createAttributeDetail(Run, DefaultAnnotationContainer, String, String, String)} instead
+     */
+    @Deprecated
+    protected AttributeDetail createAttributeDetail(final AbstractBuild<?, ?> owner, final DefaultAnnotationContainer annotations,
+            final String displayName, final String header, final String defaultEncoding) {
+        return createAttributeDetail((Run<?, ?>) owner, annotations, displayName, header, defaultEncoding);
+    }
+
+    /**
+     * @deprecated use {@link #createTrendDetails(String, Run, AnnotationContainer, Collection, Collection, Collection, String, String)} instead
+     */
+    @Deprecated
+    public Object createTrendDetails(final String link, final AbstractBuild<?, ?> owner,
+            final AnnotationContainer container, final Collection<FileAnnotation> fixedAnnotations,
+            final Collection<FileAnnotation> newAnnotations, final Collection<String> errors,
+            final String defaultEncoding, final String displayName) {
+        return createTrendDetails(link, (Run<?, ?>) owner, container, fixedAnnotations, newAnnotations, errors, defaultEncoding, displayName);
+    }
+
+    /**
+     * @deprecated use {@link #createDetails(String, Run, AnnotationContainer, String, String)} instead
+     */
+    @Deprecated
+    public Object createDetails(final String link, final AbstractBuild<?, ?> owner, final AnnotationContainer container,
+            final String defaultEncoding, final String displayName) {
+        return createDetails(link, (Run<?, ?>) owner, container, defaultEncoding, displayName);
     }
 }

--- a/src/main/java/hudson/plugins/analysis/views/ErrorDetail.java
+++ b/src/main/java/hudson/plugins/analysis/views/ErrorDetail.java
@@ -2,9 +2,6 @@ package hudson.plugins.analysis.views;
 
 import java.util.Collection;
 
-import org.kohsuke.accmod.Restricted;
-import org.kohsuke.accmod.restrictions.NoExternalUse;
-
 import com.infradna.tool.bridge_method_injector.WithBridgeMethods;
 
 import hudson.model.AbstractBuild;

--- a/src/main/java/hudson/plugins/analysis/views/ErrorDetail.java
+++ b/src/main/java/hudson/plugins/analysis/views/ErrorDetail.java
@@ -53,9 +53,8 @@ public class ErrorDetail implements ModelObject  {
      * 
      * @see {@link WithBridgeMethods}
      */
-    @Restricted(NoExternalUse.class)
     @Deprecated
-    public final Object getAbstractBuild(Run owner, Class targetClass) {
+    private final Object getAbstractBuild(Run owner, Class targetClass) {
       return owner instanceof AbstractBuild ? (AbstractBuild) owner : null;
     }
 

--- a/src/main/java/hudson/plugins/analysis/views/ErrorDetail.java
+++ b/src/main/java/hudson/plugins/analysis/views/ErrorDetail.java
@@ -2,6 +2,7 @@ package hudson.plugins.analysis.views;
 
 import java.util.Collection;
 
+import hudson.model.AbstractBuild;
 import hudson.model.Run;
 import hudson.model.ModelObject;
 
@@ -52,6 +53,21 @@ public class ErrorDetail implements ModelObject  {
      */
     public Collection<String> getErrors() {
         return errors;
+    }
+
+    /**
+     * Creates a new instance of <code>ErrorDetail</code>.
+     *
+     * @param owner
+     *            current build as owner of this action.
+     * @param errors
+     *            all modules of the project
+     * @deprecated use {@link #ErrorDetail(Run, Collection)} instead
+     */
+    @Deprecated
+    public ErrorDetail(final AbstractBuild<?, ?> owner, final Collection<String> errors) {
+        this.owner = owner;
+        this.errors = errors;
     }
 }
 

--- a/src/main/java/hudson/plugins/analysis/views/ErrorDetail.java
+++ b/src/main/java/hudson/plugins/analysis/views/ErrorDetail.java
@@ -2,7 +2,7 @@ package hudson.plugins.analysis.views;
 
 import java.util.Collection;
 
-import hudson.model.AbstractBuild;
+import hudson.model.Run;
 import hudson.model.ModelObject;
 
 import hudson.plugins.analysis.Messages;
@@ -14,7 +14,7 @@ import hudson.plugins.analysis.Messages;
  */
 public class ErrorDetail implements ModelObject  {
     /** Current build as owner of this action. */
-    private final AbstractBuild<?, ?> owner;
+    private final Run<?, ?> owner;
     /** All errors of the project. */
     private final Collection<String> errors;
 
@@ -26,7 +26,7 @@ public class ErrorDetail implements ModelObject  {
      * @param errors
      *            all modules of the project
      */
-    public ErrorDetail(final AbstractBuild<?, ?> owner, final Collection<String> errors) {
+    public ErrorDetail(final Run<?, ?> owner, final Collection<String> errors) {
         this.owner = owner;
         this.errors = errors;
     }
@@ -36,7 +36,7 @@ public class ErrorDetail implements ModelObject  {
      *
      * @return the owner
      */
-    public final AbstractBuild<?, ?> getOwner() {
+    public final Run<?, ?> getOwner() {
         return owner;
     }
 

--- a/src/main/java/hudson/plugins/analysis/views/ErrorDetail.java
+++ b/src/main/java/hudson/plugins/analysis/views/ErrorDetail.java
@@ -2,6 +2,11 @@ package hudson.plugins.analysis.views;
 
 import java.util.Collection;
 
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+import com.infradna.tool.bridge_method_injector.WithBridgeMethods;
+
 import hudson.model.AbstractBuild;
 import hudson.model.Run;
 import hudson.model.ModelObject;
@@ -37,8 +42,21 @@ public class ErrorDetail implements ModelObject  {
      *
      * @return the owner
      */
+    @WithBridgeMethods(value=AbstractBuild.class, adapterMethod="getAbstractBuild")
     public final Run<?, ?> getOwner() {
         return owner;
+    }
+
+    /**
+     * Added for backward compatibility. It generates <pre>AbstractBuild getOwner()</pre> bytecode during the build
+     * process, so old implementations can use that signature.
+     * 
+     * @see {@link WithBridgeMethods}
+     */
+    @Restricted(NoExternalUse.class)
+    @Deprecated
+    public final Object getAbstractBuild(Run owner, Class targetClass) {
+      return owner instanceof AbstractBuild ? (AbstractBuild) owner : null;
     }
 
     @Override

--- a/src/main/java/hudson/plugins/analysis/views/FileDetail.java
+++ b/src/main/java/hudson/plugins/analysis/views/FileDetail.java
@@ -3,6 +3,7 @@ package hudson.plugins.analysis.views;
 import java.util.ArrayList;
 import java.util.Collection;
 
+import hudson.model.AbstractBuild;
 import hudson.model.Run;
 
 import hudson.plugins.analysis.util.model.WorkspaceFile;
@@ -67,6 +68,27 @@ public class FileDetail extends AbstractAnnotationsDetail {
     @Override
     public WorkspaceFile getFile(final String name) {
         return file;
+    }
+
+    /**
+     * Creates a new instance of <code>ModuleDetail</code>.
+     *
+     * @param owner
+     *            current build as owner of this action.
+     * @param detailFactory
+     *            factory to create detail objects with
+     * @param file
+     *            the file to show the details for
+     * @param defaultEncoding
+     *            the default encoding to be used when reading and parsing files
+     * @param header
+     *            header to be shown on detail page
+     * @deprecated use {@link #FileDetail(Run, DetailFactory, WorkspaceFile, String, String)} instead
+     */
+    @Deprecated
+    public FileDetail(final AbstractBuild<?, ?> owner, final DetailFactory detailFactory, final WorkspaceFile file, final String defaultEncoding, final String header) {
+        super(owner, detailFactory, file.getAnnotations(), defaultEncoding, header, Hierarchy.FILE);
+        this.file = file;
     }
 }
 

--- a/src/main/java/hudson/plugins/analysis/views/FileDetail.java
+++ b/src/main/java/hudson/plugins/analysis/views/FileDetail.java
@@ -3,7 +3,7 @@ package hudson.plugins.analysis.views;
 import java.util.ArrayList;
 import java.util.Collection;
 
-import hudson.model.AbstractBuild;
+import hudson.model.Run;
 
 import hudson.plugins.analysis.util.model.WorkspaceFile;
 
@@ -32,7 +32,7 @@ public class FileDetail extends AbstractAnnotationsDetail {
      * @param header
      *            header to be shown on detail page
      */
-    public FileDetail(final AbstractBuild<?, ?> owner, final DetailFactory detailFactory, final WorkspaceFile file, final String defaultEncoding, final String header) {
+    public FileDetail(final Run<?, ?> owner, final DetailFactory detailFactory, final WorkspaceFile file, final String defaultEncoding, final String header) {
         super(owner, detailFactory, file.getAnnotations(), defaultEncoding, header, Hierarchy.FILE);
         this.file = file;
     }

--- a/src/main/java/hudson/plugins/analysis/views/FileDetail.java
+++ b/src/main/java/hudson/plugins/analysis/views/FileDetail.java
@@ -87,8 +87,7 @@ public class FileDetail extends AbstractAnnotationsDetail {
      */
     @Deprecated
     public FileDetail(final AbstractBuild<?, ?> owner, final DetailFactory detailFactory, final WorkspaceFile file, final String defaultEncoding, final String header) {
-        super(owner, detailFactory, file.getAnnotations(), defaultEncoding, header, Hierarchy.FILE);
-        this.file = file;
+        this((Run<?, ?>)owner, detailFactory, file, defaultEncoding, header);
     }
 }
 

--- a/src/main/java/hudson/plugins/analysis/views/FixedWarningsDetail.java
+++ b/src/main/java/hudson/plugins/analysis/views/FixedWarningsDetail.java
@@ -57,7 +57,7 @@ public class FixedWarningsDetail extends AbstractAnnotationsDetail {
      */
     @Deprecated
     public FixedWarningsDetail(final AbstractBuild<?, ?> owner, final DetailFactory detailFactory, final Collection<FileAnnotation> fixedWarnings, final String defaultEncoding, final String header) {
-        super(owner, detailFactory, fixedWarnings, defaultEncoding, header, Hierarchy.PROJECT);
+        this((Run<?, ?>) owner, detailFactory, fixedWarnings, defaultEncoding, header);
     }
 }
 

--- a/src/main/java/hudson/plugins/analysis/views/FixedWarningsDetail.java
+++ b/src/main/java/hudson/plugins/analysis/views/FixedWarningsDetail.java
@@ -2,6 +2,7 @@ package hudson.plugins.analysis.views;
 
 import java.util.Collection;
 
+import hudson.model.AbstractBuild;
 import hudson.model.Run;
 
 import hudson.plugins.analysis.Messages;
@@ -37,6 +38,26 @@ public class FixedWarningsDetail extends AbstractAnnotationsDetail {
     @Override
     public String getDisplayName() {
         return Messages.FixedWarningsDetail_Name();
+    }
+
+    /**
+     * Creates a new instance of <code>FixedWarningsDetail</code>.
+     *
+     * @param owner
+     *            the current results object as owner of this action
+     * @param detailFactory
+     *            factory to create detail objects with
+     * @param fixedWarnings
+     *            all fixed warnings in this build
+     * @param defaultEncoding
+     *            the default encoding to be used when reading and parsing files
+     * @param header
+     *            header to be shown on detail page
+     * @deprecated use {@link #FixedWarningsDetail(Run, DetailFactory, Collection, String, String)} instead
+     */
+    @Deprecated
+    public FixedWarningsDetail(final AbstractBuild<?, ?> owner, final DetailFactory detailFactory, final Collection<FileAnnotation> fixedWarnings, final String defaultEncoding, final String header) {
+        super(owner, detailFactory, fixedWarnings, defaultEncoding, header, Hierarchy.PROJECT);
     }
 }
 

--- a/src/main/java/hudson/plugins/analysis/views/FixedWarningsDetail.java
+++ b/src/main/java/hudson/plugins/analysis/views/FixedWarningsDetail.java
@@ -2,7 +2,7 @@ package hudson.plugins.analysis.views;
 
 import java.util.Collection;
 
-import hudson.model.AbstractBuild;
+import hudson.model.Run;
 
 import hudson.plugins.analysis.Messages;
 import hudson.plugins.analysis.util.model.FileAnnotation;
@@ -30,7 +30,7 @@ public class FixedWarningsDetail extends AbstractAnnotationsDetail {
      * @param header
      *            header to be shown on detail page
      */
-    public FixedWarningsDetail(final AbstractBuild<?, ?> owner, final DetailFactory detailFactory, final Collection<FileAnnotation> fixedWarnings, final String defaultEncoding, final String header) {
+    public FixedWarningsDetail(final Run<?, ?> owner, final DetailFactory detailFactory, final Collection<FileAnnotation> fixedWarnings, final String defaultEncoding, final String header) {
         super(owner, detailFactory, fixedWarnings, defaultEncoding, header, Hierarchy.PROJECT);
     }
 

--- a/src/main/java/hudson/plugins/analysis/views/ModuleDetail.java
+++ b/src/main/java/hudson/plugins/analysis/views/ModuleDetail.java
@@ -1,6 +1,6 @@
 package hudson.plugins.analysis.views;
 
-import hudson.model.AbstractBuild;
+import hudson.model.Run;
 
 import hudson.plugins.analysis.Messages;
 import hudson.plugins.analysis.util.model.MavenModule;
@@ -30,7 +30,7 @@ public class ModuleDetail extends AbstractAnnotationsDetail {
      * @param header
      *            header to be shown on detail page
      */
-    public ModuleDetail(final AbstractBuild<?, ?> owner, final DetailFactory detailFactory, final MavenModule module, final String defaultEncoding, final String header) {
+    public ModuleDetail(final Run<?, ?> owner, final DetailFactory detailFactory, final MavenModule module, final String defaultEncoding, final String header) {
         super(owner, detailFactory, module.getAnnotations(), defaultEncoding, header, Hierarchy.MODULE);
         this.module = module;
     }

--- a/src/main/java/hudson/plugins/analysis/views/ModuleDetail.java
+++ b/src/main/java/hudson/plugins/analysis/views/ModuleDetail.java
@@ -80,8 +80,7 @@ public class ModuleDetail extends AbstractAnnotationsDetail {
      */
     @Deprecated
     public ModuleDetail(final AbstractBuild<?, ?> owner, final DetailFactory detailFactory, final MavenModule module, final String defaultEncoding, final String header) {
-        super(owner, detailFactory, module.getAnnotations(), defaultEncoding, header, Hierarchy.MODULE);
-        this.module = module;
+        this((Run<?, ?>) owner, detailFactory, module, defaultEncoding, header);
     }
 }
 

--- a/src/main/java/hudson/plugins/analysis/views/ModuleDetail.java
+++ b/src/main/java/hudson/plugins/analysis/views/ModuleDetail.java
@@ -1,5 +1,6 @@
 package hudson.plugins.analysis.views;
 
+import hudson.model.AbstractBuild;
 import hudson.model.Run;
 
 import hudson.plugins.analysis.Messages;
@@ -60,6 +61,27 @@ public class ModuleDetail extends AbstractAnnotationsDetail {
      */
     public String getToolTip(final String packageName) {
         return module.getPackage(packageName).getToolTip();
+    }
+
+    /**
+     * Creates a new instance of <code>ModuleDetail</code>.
+     *
+     * @param owner
+     *            current build as owner of this action.
+     * @param detailFactory
+     *            factory to create detail objects with
+     * @param module
+     *            the module to show the details for
+     * @param defaultEncoding
+     *            the default encoding to be used when reading and parsing files
+     * @param header
+     *            header to be shown on detail page
+     * @deprecated use {@link #ModuleDetail(Run, DetailFactory, MavenModule, String, String)} instead
+     */
+    @Deprecated
+    public ModuleDetail(final AbstractBuild<?, ?> owner, final DetailFactory detailFactory, final MavenModule module, final String defaultEncoding, final String header) {
+        super(owner, detailFactory, module.getAnnotations(), defaultEncoding, header, Hierarchy.MODULE);
+        this.module = module;
     }
 }
 

--- a/src/main/java/hudson/plugins/analysis/views/NewWarningsDetail.java
+++ b/src/main/java/hudson/plugins/analysis/views/NewWarningsDetail.java
@@ -57,7 +57,7 @@ public class NewWarningsDetail extends AbstractAnnotationsDetail {
      */
     @Deprecated
     public NewWarningsDetail(final AbstractBuild<?, ?> owner, final DetailFactory detailFactory, final Collection<FileAnnotation> newWarnings, final String defaultEncoding, final String header) {
-        super(owner, detailFactory, newWarnings, defaultEncoding, header, Hierarchy.PROJECT);
+        this((Run<?, ?>) owner, detailFactory, newWarnings, defaultEncoding, header);
     }
 }
 

--- a/src/main/java/hudson/plugins/analysis/views/NewWarningsDetail.java
+++ b/src/main/java/hudson/plugins/analysis/views/NewWarningsDetail.java
@@ -2,6 +2,7 @@ package hudson.plugins.analysis.views;
 
 import java.util.Collection;
 
+import hudson.model.AbstractBuild;
 import hudson.model.Run;
 
 import hudson.plugins.analysis.Messages;
@@ -37,6 +38,26 @@ public class NewWarningsDetail extends AbstractAnnotationsDetail {
     @Override
     public String getDisplayName() {
         return Messages.NewWarningsDetail_Name();
+    }
+
+    /**
+     * Creates a new instance of <code>NewWarningsDetail</code>.
+     *
+     * @param owner
+     *            the current build as owner of this action
+     * @param detailFactory
+     *            factory to create detail objects with
+     * @param newWarnings
+     *            all new warnings in this build
+     * @param defaultEncoding
+     *            the default encoding to be used when reading and parsing files
+     * @param header
+     *            header to be shown on detail page
+     * @deprecated use {@link #NewWarningsDetail(Run, DetailFactory, Collection, String, String)} instead
+     */
+    @Deprecated
+    public NewWarningsDetail(final AbstractBuild<?, ?> owner, final DetailFactory detailFactory, final Collection<FileAnnotation> newWarnings, final String defaultEncoding, final String header) {
+        super(owner, detailFactory, newWarnings, defaultEncoding, header, Hierarchy.PROJECT);
     }
 }
 

--- a/src/main/java/hudson/plugins/analysis/views/NewWarningsDetail.java
+++ b/src/main/java/hudson/plugins/analysis/views/NewWarningsDetail.java
@@ -2,7 +2,7 @@ package hudson.plugins.analysis.views;
 
 import java.util.Collection;
 
-import hudson.model.AbstractBuild;
+import hudson.model.Run;
 
 import hudson.plugins.analysis.Messages;
 import hudson.plugins.analysis.util.model.FileAnnotation;
@@ -30,7 +30,7 @@ public class NewWarningsDetail extends AbstractAnnotationsDetail {
      * @param header
      *            header to be shown on detail page
      */
-    public NewWarningsDetail(final AbstractBuild<?, ?> owner, final DetailFactory detailFactory, final Collection<FileAnnotation> newWarnings, final String defaultEncoding, final String header) {
+    public NewWarningsDetail(final Run<?, ?> owner, final DetailFactory detailFactory, final Collection<FileAnnotation> newWarnings, final String defaultEncoding, final String header) {
         super(owner, detailFactory, newWarnings, defaultEncoding, header, Hierarchy.PROJECT);
     }
 

--- a/src/main/java/hudson/plugins/analysis/views/PackageDetail.java
+++ b/src/main/java/hudson/plugins/analysis/views/PackageDetail.java
@@ -1,6 +1,6 @@
 package hudson.plugins.analysis.views;
 
-import hudson.model.AbstractBuild;
+import hudson.model.Run;
 
 import hudson.plugins.analysis.util.model.JavaPackage;
 
@@ -29,7 +29,7 @@ public class PackageDetail extends AbstractAnnotationsDetail {
      * @param header
      *            header to be shown on detail page
      */
-    public PackageDetail(final AbstractBuild<?, ?> owner, final DetailFactory detailFactory, final JavaPackage javaPackage, final String defaultEncoding, final String header) {
+    public PackageDetail(final Run<?, ?> owner, final DetailFactory detailFactory, final JavaPackage javaPackage, final String defaultEncoding, final String header) {
         super(owner, detailFactory, javaPackage.getAnnotations(), defaultEncoding, header, Hierarchy.PACKAGE);
         this.javaPackage = javaPackage;
     }

--- a/src/main/java/hudson/plugins/analysis/views/PackageDetail.java
+++ b/src/main/java/hudson/plugins/analysis/views/PackageDetail.java
@@ -1,5 +1,6 @@
 package hudson.plugins.analysis.views;
 
+import hudson.model.AbstractBuild;
 import hudson.model.Run;
 
 import hudson.plugins.analysis.util.model.JavaPackage;
@@ -47,6 +48,27 @@ public class PackageDetail extends AbstractAnnotationsDetail {
     @Override
     public String getDisplayName() {
         return javaPackage.getName();
+    }
+
+    /**
+     * Creates a new instance of <code>ModuleDetail</code>.
+     *
+     * @param owner
+     *            current build as owner of this action.
+     * @param detailFactory
+     *            factory to create detail objects with
+     * @param javaPackage
+     *            the package to show the details for
+     * @param defaultEncoding
+     *            the default encoding to be used when reading and parsing files
+     * @param header
+     *            header to be shown on detail page
+     * @deprecated use {@link #PackageDetail(Run, DetailFactory, JavaPackage, String, String)} instead
+     */
+    @Deprecated
+    public PackageDetail(final AbstractBuild<?, ?> owner, final DetailFactory detailFactory, final JavaPackage javaPackage, final String defaultEncoding, final String header) {
+        super(owner, detailFactory, javaPackage.getAnnotations(), defaultEncoding, header, Hierarchy.PACKAGE);
+        this.javaPackage = javaPackage;
     }
 }
 

--- a/src/main/java/hudson/plugins/analysis/views/PackageDetail.java
+++ b/src/main/java/hudson/plugins/analysis/views/PackageDetail.java
@@ -67,8 +67,7 @@ public class PackageDetail extends AbstractAnnotationsDetail {
      */
     @Deprecated
     public PackageDetail(final AbstractBuild<?, ?> owner, final DetailFactory detailFactory, final JavaPackage javaPackage, final String defaultEncoding, final String header) {
-        super(owner, detailFactory, javaPackage.getAnnotations(), defaultEncoding, header, Hierarchy.PACKAGE);
-        this.javaPackage = javaPackage;
+        this((Run<?, ?>) owner, detailFactory, javaPackage, defaultEncoding, header);
     }
 }
 

--- a/src/main/java/hudson/plugins/analysis/views/PrioritiesDetail.java
+++ b/src/main/java/hudson/plugins/analysis/views/PrioritiesDetail.java
@@ -74,8 +74,7 @@ public class PrioritiesDetail extends AbstractAnnotationsDetail {
      */
     @Deprecated
     public PrioritiesDetail(final AbstractBuild<?, ?> owner, final DetailFactory detailFactory, final Collection<FileAnnotation> annotations, final Priority priority, final String defaultEncoding, final String header) {
-        super(owner, detailFactory, annotations, defaultEncoding, header, Hierarchy.PROJECT);
-        this.priority = priority;
+        this((Run<?, ?>) owner, detailFactory, annotations, priority, defaultEncoding, header);
     }
 }
 

--- a/src/main/java/hudson/plugins/analysis/views/PrioritiesDetail.java
+++ b/src/main/java/hudson/plugins/analysis/views/PrioritiesDetail.java
@@ -2,6 +2,7 @@ package hudson.plugins.analysis.views;
 
 import java.util.Collection;
 
+import hudson.model.AbstractBuild;
 import hudson.model.Run;
 
 import hudson.plugins.analysis.util.model.FileAnnotation;
@@ -52,6 +53,29 @@ public class PrioritiesDetail extends AbstractAnnotationsDetail {
     @Override
     public String getDisplayName() {
         return priority.getLongLocalizedString();
+    }
+
+    /**
+     * Creates a new instance of <code>ModuleDetail</code>.
+     *
+     * @param owner
+     *            current build as owner of this action.
+     * @param detailFactory
+     *            factory to create detail objects with
+     * @param annotations
+     *            the package to show the details for
+     * @param priority
+     *            the priority of all annotations
+     * @param defaultEncoding
+     *            the default encoding to be used when reading and parsing files
+     * @param header
+     *            header to be shown on detail page
+     * @deprecated use {@link #PrioritiesDetail(Run, DetailFactory, Collection, Priority, String, String)} instead
+     */
+    @Deprecated
+    public PrioritiesDetail(final AbstractBuild<?, ?> owner, final DetailFactory detailFactory, final Collection<FileAnnotation> annotations, final Priority priority, final String defaultEncoding, final String header) {
+        super(owner, detailFactory, annotations, defaultEncoding, header, Hierarchy.PROJECT);
+        this.priority = priority;
     }
 }
 

--- a/src/main/java/hudson/plugins/analysis/views/PrioritiesDetail.java
+++ b/src/main/java/hudson/plugins/analysis/views/PrioritiesDetail.java
@@ -2,7 +2,7 @@ package hudson.plugins.analysis.views;
 
 import java.util.Collection;
 
-import hudson.model.AbstractBuild;
+import hudson.model.Run;
 
 import hudson.plugins.analysis.util.model.FileAnnotation;
 import hudson.plugins.analysis.util.model.Priority;
@@ -34,7 +34,7 @@ public class PrioritiesDetail extends AbstractAnnotationsDetail {
      * @param header
      *            header to be shown on detail page
      */
-    public PrioritiesDetail(final AbstractBuild<?, ?> owner, final DetailFactory detailFactory, final Collection<FileAnnotation> annotations, final Priority priority, final String defaultEncoding, final String header) {
+    public PrioritiesDetail(final Run<?, ?> owner, final DetailFactory detailFactory, final Collection<FileAnnotation> annotations, final Priority priority, final String defaultEncoding, final String header) {
         super(owner, detailFactory, annotations, defaultEncoding, header, Hierarchy.PROJECT);
         this.priority = priority;
     }

--- a/src/main/java/hudson/plugins/analysis/views/PriorityDetailFactory.java
+++ b/src/main/java/hudson/plugins/analysis/views/PriorityDetailFactory.java
@@ -87,5 +87,22 @@ public class PriorityDetailFactory {
             final String defaultEncoding, final String header) {
         return new PrioritiesDetail(owner, detailFactory, container.getAnnotations(priority), priority, defaultEncoding, header);
     }
+
+    /**
+     * @deprecated use {@link #create(String, Run, AnnotationContainer, String, String)} instead
+     */
+    @Deprecated
+    public PrioritiesDetail create(final String priority, final AbstractBuild<?, ?> owner, final AnnotationContainer container, final String defaultEncoding, final String header) {
+        return create(priority, (Run<?, ?>) owner, container, defaultEncoding, header);
+    }
+
+    /**
+     * @deprecated use {@link #createPrioritiesDetail(Priority, Run, AnnotationContainer, String, String)} instead
+     */
+    @Deprecated
+    protected PrioritiesDetail createPrioritiesDetail(final Priority priority, final AbstractBuild<?, ?> owner, final AnnotationContainer container,
+            final String defaultEncoding, final String header) {
+        return createPrioritiesDetail(priority, (Run<?, ?>) owner, container, defaultEncoding, header);
+    }
 }
 

--- a/src/main/java/hudson/plugins/analysis/views/PriorityDetailFactory.java
+++ b/src/main/java/hudson/plugins/analysis/views/PriorityDetailFactory.java
@@ -1,6 +1,7 @@
 package hudson.plugins.analysis.views;
 
 import hudson.model.AbstractBuild;
+import hudson.model.Run;
 
 import hudson.plugins.analysis.util.model.AnnotationContainer;
 import hudson.plugins.analysis.util.model.Priority;
@@ -54,7 +55,7 @@ public class PriorityDetailFactory {
      *            the default encoding to be used when reading and parsing files
      * @return the priority detail
      */
-    public PrioritiesDetail create(final String priority, final AbstractBuild<?, ?> owner, final AnnotationContainer container, final String defaultEncoding, final String header) {
+    public PrioritiesDetail create(final String priority, final Run<?, ?> owner, final AnnotationContainer container, final String defaultEncoding, final String header) {
         if (Priority.HIGH.toString().equalsIgnoreCase(priority)) {
             return createPrioritiesDetail(Priority.HIGH, owner, container, defaultEncoding, header);
         }
@@ -82,7 +83,7 @@ public class PriorityDetailFactory {
      *            header to show
      * @return the priority detail
      */
-    protected PrioritiesDetail createPrioritiesDetail(final Priority priority, final AbstractBuild<?, ?> owner, final AnnotationContainer container,
+    protected PrioritiesDetail createPrioritiesDetail(final Priority priority, final Run<?, ?> owner, final AnnotationContainer container,
             final String defaultEncoding, final String header) {
         return new PrioritiesDetail(owner, detailFactory, container.getAnnotations(priority), priority, defaultEncoding, header);
     }

--- a/src/main/java/hudson/plugins/analysis/views/PriorityDetailFactory.java
+++ b/src/main/java/hudson/plugins/analysis/views/PriorityDetailFactory.java
@@ -1,5 +1,7 @@
 package hudson.plugins.analysis.views;
 
+import javax.annotation.Nonnull;
+
 import hudson.model.AbstractBuild;
 import hudson.model.Run;
 
@@ -55,7 +57,7 @@ public class PriorityDetailFactory {
      *            the default encoding to be used when reading and parsing files
      * @return the priority detail
      */
-    public PrioritiesDetail create(final String priority, final Run<?, ?> owner, final AnnotationContainer container, final String defaultEncoding, final String header) {
+    public PrioritiesDetail create(final String priority, @Nonnull final Run<?, ?> owner, final AnnotationContainer container, final String defaultEncoding, final String header) {
         if (Priority.HIGH.toString().equalsIgnoreCase(priority)) {
             return createPrioritiesDetail(Priority.HIGH, owner, container, defaultEncoding, header);
         }
@@ -83,7 +85,7 @@ public class PriorityDetailFactory {
      *            header to show
      * @return the priority detail
      */
-    protected PrioritiesDetail createPrioritiesDetail(final Priority priority, final Run<?, ?> owner, final AnnotationContainer container,
+    protected PrioritiesDetail createPrioritiesDetail(final Priority priority, @Nonnull final Run<?, ?> owner, final AnnotationContainer container,
             final String defaultEncoding, final String header) {
         return new PrioritiesDetail(owner, detailFactory, container.getAnnotations(priority), priority, defaultEncoding, header);
     }

--- a/src/main/java/hudson/plugins/analysis/views/PriorityDetailFactory.java
+++ b/src/main/java/hudson/plugins/analysis/views/PriorityDetailFactory.java
@@ -5,6 +5,7 @@ import javax.annotation.Nonnull;
 import hudson.model.AbstractBuild;
 import hudson.model.Run;
 
+import hudson.plugins.analysis.util.Compatibility;
 import hudson.plugins.analysis.util.model.AnnotationContainer;
 import hudson.plugins.analysis.util.model.Priority;
 
@@ -58,16 +59,22 @@ public class PriorityDetailFactory {
      * @return the priority detail
      */
     public PrioritiesDetail create(final String priority, @Nonnull final Run<?, ?> owner, final AnnotationContainer container, final String defaultEncoding, final String header) {
-        if (Priority.HIGH.toString().equalsIgnoreCase(priority)) {
-            return createPrioritiesDetail(Priority.HIGH, owner, container, defaultEncoding, header);
+        if (owner instanceof AbstractBuild && Compatibility.isOverridden(PriorityDetailFactory.class, getClass(), "create", 
+                String.class, AbstractBuild.class, AnnotationContainer.class, String.class, String.class)) {
+            return create(priority, (AbstractBuild<?, ?>) owner, container, defaultEncoding, header);
         }
-        else if (Priority.NORMAL.toString().equalsIgnoreCase(priority)) {
-            return createPrioritiesDetail(Priority.NORMAL, owner, container, defaultEncoding, header);
+        else {
+            if (Priority.HIGH.toString().equalsIgnoreCase(priority)) {
+                return createPrioritiesDetail(Priority.HIGH, owner, container, defaultEncoding, header);
+            }
+            else if (Priority.NORMAL.toString().equalsIgnoreCase(priority)) {
+                return createPrioritiesDetail(Priority.NORMAL, owner, container, defaultEncoding, header);
+            }
+            else if (Priority.LOW.toString().equalsIgnoreCase(priority)) {
+                return createPrioritiesDetail(Priority.LOW, owner, container, defaultEncoding, header);
+            }
+            throw new IllegalArgumentException("Wrong priority provided: " + priority);
         }
-        else if (Priority.LOW.toString().equalsIgnoreCase(priority)) {
-            return createPrioritiesDetail(Priority.LOW, owner, container, defaultEncoding, header);
-        }
-        throw new IllegalArgumentException("Wrong priority provided: " + priority);
     }
 
     /**
@@ -87,7 +94,13 @@ public class PriorityDetailFactory {
      */
     protected PrioritiesDetail createPrioritiesDetail(final Priority priority, @Nonnull final Run<?, ?> owner, final AnnotationContainer container,
             final String defaultEncoding, final String header) {
-        return new PrioritiesDetail(owner, detailFactory, container.getAnnotations(priority), priority, defaultEncoding, header);
+        if (owner instanceof AbstractBuild && Compatibility.isOverridden(PriorityDetailFactory.class, getClass(), "createPrioritiesDetail", 
+                Priority.class, AbstractBuild.class, AnnotationContainer.class, String.class, String.class)) {
+            return createPrioritiesDetail(priority, (AbstractBuild<?, ?>) owner, container, defaultEncoding, header);
+        }
+        else {
+            return new PrioritiesDetail(owner, detailFactory, container.getAnnotations(priority), priority, defaultEncoding, header);
+        }
     }
 
     /**

--- a/src/main/java/hudson/plugins/analysis/views/SourceDetail.java
+++ b/src/main/java/hudson/plugins/analysis/views/SourceDetail.java
@@ -19,8 +19,9 @@ import de.java2html.javasource.JavaSource;
 import de.java2html.javasource.JavaSourceParser;
 import de.java2html.options.JavaSourceConversionOptions;
 
-import hudson.model.AbstractBuild;
+import hudson.model.Run;
 import hudson.model.ModelObject;
+
 import hudson.plugins.analysis.util.EncodingValidator;
 import hudson.plugins.analysis.util.model.FileAnnotation;
 import hudson.plugins.analysis.util.model.LineRange;
@@ -40,7 +41,7 @@ public class SourceDetail implements ModelObject {
     /** Color for all other annotation ranges. */
     private static final String OTHER_COLOR = "#FCE94F";
     /** The current build as owner of this object. */
-    private final AbstractBuild<?, ?> owner;
+    private final Run<?, ?> owner;
     /** Stripped file name of this annotation without the path prefix. */
     private final String fileName;
     /** The annotation to be shown. */
@@ -60,7 +61,7 @@ public class SourceDetail implements ModelObject {
      * @param defaultEncoding
      *            the default encoding to be used when reading and parsing files
      */
-    public SourceDetail(final AbstractBuild<?, ?> owner, final FileAnnotation annotation, final String defaultEncoding) {
+    public SourceDetail(final Run<?, ?> owner, final FileAnnotation annotation, final String defaultEncoding) {
         this.owner = owner;
         this.annotation = annotation;
         this.defaultEncoding = defaultEncoding;
@@ -241,7 +242,7 @@ public class SourceDetail implements ModelObject {
      *
      * @return the build
      */
-    public AbstractBuild<?, ?> getOwner() {
+    public Run<?, ?> getOwner() {
         return owner;
     }
 

--- a/src/main/java/hudson/plugins/analysis/views/SourceDetail.java
+++ b/src/main/java/hudson/plugins/analysis/views/SourceDetail.java
@@ -258,9 +258,8 @@ public class SourceDetail implements ModelObject {
      * 
      * @see {@link WithBridgeMethods}
      */
-    @Restricted(NoExternalUse.class)
     @Deprecated
-    public final Object getAbstractBuild(Run owner, Class targetClass) {
+    private final Object getAbstractBuild(Run owner, Class targetClass) {
       return owner instanceof AbstractBuild ? (AbstractBuild) owner : null;
     }
 
@@ -286,12 +285,7 @@ public class SourceDetail implements ModelObject {
      */
     @Deprecated
     public SourceDetail(final AbstractBuild<?, ?> owner, final FileAnnotation annotation, final String defaultEncoding) {
-        this.owner = owner;
-        this.annotation = annotation;
-        this.defaultEncoding = defaultEncoding;
-        fileName = StringUtils.substringAfterLast(annotation.getFileName(), "/");
-
-        initializeContent();
+        this((Run<?, ?>) owner, annotation, defaultEncoding);
     }
 }
 

--- a/src/main/java/hudson/plugins/analysis/views/SourceDetail.java
+++ b/src/main/java/hudson/plugins/analysis/views/SourceDetail.java
@@ -19,6 +19,7 @@ import de.java2html.javasource.JavaSource;
 import de.java2html.javasource.JavaSourceParser;
 import de.java2html.options.JavaSourceConversionOptions;
 
+import hudson.model.AbstractBuild;
 import hudson.model.Run;
 import hudson.model.ModelObject;
 
@@ -253,6 +254,27 @@ public class SourceDetail implements ModelObject {
      */
     public String getSourceCode() {
         return sourceCode;
+    }
+
+    /**
+     * Creates a new instance of this source code object.
+     *
+     * @param owner
+     *            the current build as owner of this object
+     * @param annotation
+     *            the warning to display in the source file
+     * @param defaultEncoding
+     *            the default encoding to be used when reading and parsing files
+     * @deprecated use {@link #SourceDetail(Run, FileAnnotation, String)} instead
+     */
+    @Deprecated
+    public SourceDetail(final AbstractBuild<?, ?> owner, final FileAnnotation annotation, final String defaultEncoding) {
+        this.owner = owner;
+        this.annotation = annotation;
+        this.defaultEncoding = defaultEncoding;
+        fileName = StringUtils.substringAfterLast(annotation.getFileName(), "/");
+
+        initializeContent();
     }
 }
 

--- a/src/main/java/hudson/plugins/analysis/views/SourceDetail.java
+++ b/src/main/java/hudson/plugins/analysis/views/SourceDetail.java
@@ -13,6 +13,10 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.LineIterator;
 import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang.StringUtils;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+import com.infradna.tool.bridge_method_injector.WithBridgeMethods;
 
 import de.java2html.converter.JavaSource2HTMLConverter;
 import de.java2html.javasource.JavaSource;
@@ -243,8 +247,21 @@ public class SourceDetail implements ModelObject {
      *
      * @return the build
      */
+    @WithBridgeMethods(value=AbstractBuild.class, adapterMethod="getAbstractBuild")
     public Run<?, ?> getOwner() {
         return owner;
+    }
+
+    /**
+     * Added for backward compatibility. It generates <pre>AbstractBuild getOwner()</pre> bytecode during the build
+     * process, so old implementations can use that signature.
+     * 
+     * @see {@link WithBridgeMethods}
+     */
+    @Restricted(NoExternalUse.class)
+    @Deprecated
+    public final Object getAbstractBuild(Run owner, Class targetClass) {
+      return owner instanceof AbstractBuild ? (AbstractBuild) owner : null;
     }
 
     /**

--- a/src/main/java/hudson/plugins/analysis/views/TabDetail.java
+++ b/src/main/java/hudson/plugins/analysis/views/TabDetail.java
@@ -2,6 +2,7 @@ package hudson.plugins.analysis.views;
 
 import java.util.Collection;
 
+import hudson.model.AbstractBuild;
 import hudson.model.Run;
 
 import hudson.plugins.analysis.util.model.FileAnnotation;
@@ -75,6 +76,27 @@ public class TabDetail extends AbstractAnnotationsDetail {
      */
     public String getFixed() {
         return "fixed.jelly";
+    }
+
+    /**
+     * Creates a new instance of {@link TabDetail}.
+     *
+     * @param owner
+     *            current build as owner of this action.
+     * @param detailFactory
+     *            factory to create detail objects with
+     * @param annotations
+     *            the module to show the details for
+     * @param url
+     *            URL to render the content of this tab
+     * @param defaultEncoding
+     *            the default encoding to be used when reading and parsing files
+     * @deprecated use {@link #TabDetail(Run, DetailFactory, Collection, String, String)} instead
+     */
+    @Deprecated
+    public TabDetail(final AbstractBuild<?, ?> owner, final DetailFactory detailFactory, final Collection<FileAnnotation> annotations, final String url, final String defaultEncoding) {
+        super(owner, detailFactory, annotations, defaultEncoding, "No Header", Hierarchy.PROJECT);
+        this.url = url;
     }
 }
 

--- a/src/main/java/hudson/plugins/analysis/views/TabDetail.java
+++ b/src/main/java/hudson/plugins/analysis/views/TabDetail.java
@@ -95,8 +95,7 @@ public class TabDetail extends AbstractAnnotationsDetail {
      */
     @Deprecated
     public TabDetail(final AbstractBuild<?, ?> owner, final DetailFactory detailFactory, final Collection<FileAnnotation> annotations, final String url, final String defaultEncoding) {
-        super(owner, detailFactory, annotations, defaultEncoding, "No Header", Hierarchy.PROJECT);
-        this.url = url;
+        this((Run<?, ?>) owner, detailFactory, annotations, url, defaultEncoding);
     }
 }
 

--- a/src/main/java/hudson/plugins/analysis/views/TabDetail.java
+++ b/src/main/java/hudson/plugins/analysis/views/TabDetail.java
@@ -2,7 +2,7 @@ package hudson.plugins.analysis.views;
 
 import java.util.Collection;
 
-import hudson.model.AbstractBuild;
+import hudson.model.Run;
 
 import hudson.plugins.analysis.util.model.FileAnnotation;
 
@@ -31,7 +31,7 @@ public class TabDetail extends AbstractAnnotationsDetail {
      * @param defaultEncoding
      *            the default encoding to be used when reading and parsing files
      */
-    public TabDetail(final AbstractBuild<?, ?> owner, final DetailFactory detailFactory, final Collection<FileAnnotation> annotations, final String url, final String defaultEncoding) {
+    public TabDetail(final Run<?, ?> owner, final DetailFactory detailFactory, final Collection<FileAnnotation> annotations, final String url, final String defaultEncoding) {
         super(owner, detailFactory, annotations, defaultEncoding, "No Header", Hierarchy.PROJECT);
         this.url = url;
     }

--- a/src/main/resources/util/thresholds.jelly
+++ b/src/main/resources/util/thresholds.jelly
@@ -70,7 +70,7 @@
   </f:entry>
   <f:block>
     <table>
-      <f:optionalBlock name="canComputeNew" title="${%compute.new.title}" checked="${instance.canComputeNew}">
+      <f:optionalBlock name="canComputeNew" title="${%compute.new.title}" checked="${instance.canComputeNew}" inline="true">
         <f:entry title="${%title.status.new}" description="${%description.status.new}">
           <table>
             <thead>

--- a/src/test/java/hudson/plugins/analysis/core/IsOverriddenTest.java
+++ b/src/test/java/hudson/plugins/analysis/core/IsOverriddenTest.java
@@ -1,12 +1,8 @@
 package hudson.plugins.analysis.core;
 
-import java.lang.reflect.InvocationTargetException;
+import static org.junit.Assert.*;
 
 import org.junit.Test;
-
-import hudson.plugins.analysis.core.HealthAwarePublisher;
-
-import static org.junit.Assert.*;
 
 /**
  * Test for {@link HealthAwarePublisher.isOverridden} method.

--- a/src/test/java/hudson/plugins/analysis/core/IsOverriddenTest.java
+++ b/src/test/java/hudson/plugins/analysis/core/IsOverriddenTest.java
@@ -4,8 +4,10 @@ import static org.junit.Assert.*;
 
 import org.junit.Test;
 
+import hudson.plugins.analysis.util.Compatibility;
+
 /**
- * Test for {@link HealthAwarePublisher.isOverridden} method.
+ * Test for {@link Compatibility.isOverridden} method.
  */
 public class IsOverriddenTest {
 
@@ -14,9 +16,9 @@ public class IsOverriddenTest {
      */
     @Test
     public void isOverriddenTest() {
-        assertTrue(HealthAwarePublisher.isOverridden(Base.class, Derived.class, "method"));
-        assertTrue(HealthAwarePublisher.isOverridden(Base.class, Intermediate.class, "method"));
-        assertFalse(HealthAwarePublisher.isOverridden(Base.class, Base.class, "method"));
+        assertTrue(Compatibility.isOverridden(Base.class, Derived.class, "method"));
+        assertTrue(Compatibility.isOverridden(Base.class, Intermediate.class, "method"));
+        assertFalse(Compatibility.isOverridden(Base.class, Base.class, "method"));
     }
 
     /**
@@ -25,7 +27,7 @@ public class IsOverriddenTest {
      */
     @Test(expected = AssertionError.class)
     public void isOverriddenNegativeTest() {
-        HealthAwarePublisher.isOverridden(Base.class, Derived.class, "method2");
+        Compatibility.isOverridden(Base.class, Derived.class, "method2");
     }
 
     public abstract class Base {

--- a/src/test/java/hudson/plugins/analysis/core/IsOverriddenTest.java
+++ b/src/test/java/hudson/plugins/analysis/core/IsOverriddenTest.java
@@ -1,0 +1,73 @@
+package hudson.plugins.analysis.core;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import org.junit.Test;
+
+import hudson.Launcher;
+import hudson.matrix.MatrixAggregator;
+import hudson.matrix.MatrixBuild;
+
+import hudson.model.BuildListener;
+
+import hudson.plugins.analysis.core.HealthAwarePublisher;
+
+import static org.junit.Assert.*;
+
+/**
+ * Test for {@link HealthAwarePublisher.isOverridden} method.
+ */
+public class IsOverriddenTest {
+
+    /**
+     * Test that a method is found by isOverriden even when it is inherited from an intermediate class.
+     */
+    @Test
+    public void isOverridenTest() throws NoSuchMethodException, SecurityException, IllegalAccessException, IllegalArgumentException, InvocationTargetException {
+        Method method = HealthAwarePublisher.class.getDeclaredMethod("isOverridden", Class.class, Class.class, String.class, Class[].class);
+        method.setAccessible(true);
+        Object o = method.invoke(getMockPublisher(), Base.class, Derived.class, "method", new Class[0]);
+        assertTrue((Boolean) o);
+
+        o = method.invoke(getMockPublisher(), Base.class, Intermediate.class, "method", new Class[0]);
+        assertTrue((Boolean) o);
+
+        o = method.invoke(getMockPublisher(), Base.class, Base.class, "method", new Class[0]);
+        assertFalse((Boolean) o);
+    }
+
+    /**
+     * Negative test.
+     * Trying to check for a method which does not exist in the hierarchy,
+     */
+    @Test(expected = NoSuchMethodException.class)
+    public void isOverriddenNegativeTest() throws Throwable {
+        Method method = HealthAwarePublisher.class.getDeclaredMethod("isOverridden", Class.class, Class.class, String.class, Class[].class);
+        method.setAccessible(true);
+        try {
+            method.invoke(getMockPublisher(), Base.class, Derived.class, "method2", new Class[0]);
+        } catch (InvocationTargetException e) {
+            throw e.getTargetException().getCause();
+        }
+    }
+
+    private HealthAwarePublisher getMockPublisher() {
+        return new HealthAwarePublisher("") {
+            @Override
+            public MatrixAggregator createAggregator(MatrixBuild build, Launcher launcher, BuildListener listener) {
+                return null;
+            }
+        };
+    }
+
+    public abstract class Base {
+        protected abstract void method();
+    }
+    public abstract class Intermediate extends Base {
+        protected void method() {}
+    }
+    public class Derived extends Intermediate {}
+
+}
+

--- a/src/test/java/hudson/plugins/analysis/core/IsOverriddenTest.java
+++ b/src/test/java/hudson/plugins/analysis/core/IsOverriddenTest.java
@@ -1,15 +1,8 @@
 package hudson.plugins.analysis.core;
 
 import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 
 import org.junit.Test;
-
-import hudson.Launcher;
-import hudson.matrix.MatrixAggregator;
-import hudson.matrix.MatrixBuild;
-
-import hudson.model.BuildListener;
 
 import hudson.plugins.analysis.core.HealthAwarePublisher;
 
@@ -21,44 +14,22 @@ import static org.junit.Assert.*;
 public class IsOverriddenTest {
 
     /**
-     * Test that a method is found by isOverriden even when it is inherited from an intermediate class.
+     * Test that a method is found by isOverridden even when it is inherited from an intermediate class.
      */
     @Test
-    public void isOverridenTest() throws NoSuchMethodException, SecurityException, IllegalAccessException, IllegalArgumentException, InvocationTargetException {
-        Method method = HealthAwarePublisher.class.getDeclaredMethod("isOverridden", Class.class, Class.class, String.class, Class[].class);
-        method.setAccessible(true);
-        Object o = method.invoke(getMockPublisher(), Base.class, Derived.class, "method", new Class[0]);
-        assertTrue((Boolean) o);
-
-        o = method.invoke(getMockPublisher(), Base.class, Intermediate.class, "method", new Class[0]);
-        assertTrue((Boolean) o);
-
-        o = method.invoke(getMockPublisher(), Base.class, Base.class, "method", new Class[0]);
-        assertFalse((Boolean) o);
+    public void isOverriddenTest() {
+        assertTrue(HealthAwarePublisher.isOverridden(Base.class, Derived.class, "method"));
+        assertTrue(HealthAwarePublisher.isOverridden(Base.class, Intermediate.class, "method"));
+        assertFalse(HealthAwarePublisher.isOverridden(Base.class, Base.class, "method"));
     }
 
     /**
      * Negative test.
      * Trying to check for a method which does not exist in the hierarchy,
      */
-    @Test(expected = NoSuchMethodException.class)
-    public void isOverriddenNegativeTest() throws Throwable {
-        Method method = HealthAwarePublisher.class.getDeclaredMethod("isOverridden", Class.class, Class.class, String.class, Class[].class);
-        method.setAccessible(true);
-        try {
-            method.invoke(getMockPublisher(), Base.class, Derived.class, "method2", new Class[0]);
-        } catch (InvocationTargetException e) {
-            throw e.getTargetException().getCause();
-        }
-    }
-
-    private HealthAwarePublisher getMockPublisher() {
-        return new HealthAwarePublisher("") {
-            @Override
-            public MatrixAggregator createAggregator(MatrixBuild build, Launcher launcher, BuildListener listener) {
-                return null;
-            }
-        };
+    @Test(expected = AssertionError.class)
+    public void isOverriddenNegativeTest() {
+        HealthAwarePublisher.isOverridden(Base.class, Derived.class, "method2");
     }
 
     public abstract class Base {


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-25977

Required changes to make this plugin compatible with Workflow jobs. After this changes any plugin extending ```analysis-core``` can be adapted to use Workflow too.

Requires upstream: https://github.com/jenkinsci/analysis-pom-plugin/pull/2

For downstream PRs, use this dependency to analysis-core (it contains this PR as a snapshot):

```
<dependency>
    <groupId>org.jvnet.hudson.plugins</groupId>
    <artifactId>analysis-core</artifactId>
    <version>1.73-beta-SNAPSHOT</version><!-- TODO: change to 1.73 before release -->
</dependency>
```

Downstream PRs:
* https://github.com/jenkinsci/findbugs-plugin/pull/9
* https://github.com/jenkinsci/tasks-plugin/pull/2
* https://github.com/jenkinsci/checkstyle-plugin/pull/8
* https://github.com/jenkinsci/pmd-plugin/pull/3
* https://github.com/jenkinsci/analysis-collector-plugin/pull/2
* https://github.com/jenkinsci/dry-plugin/pull/3
* https://github.com/jenkinsci/android-lint-plugin/pull/6
* https://github.com/jenkinsci/dependency-check-plugin/pull/3