### PR TITLE
Add priority "none"

### DIFF
--- a/src/main/java/hudson/plugins/analysis/core/AbstractHealthDescriptor.java
+++ b/src/main/java/hudson/plugins/analysis/core/AbstractHealthDescriptor.java
@@ -1,11 +1,11 @@
 package hudson.plugins.analysis.core;
 
+import static hudson.plugins.analysis.util.ThresholdValidator.*;
+
 import org.apache.commons.lang.StringUtils;
 import org.jvnet.localizer.Localizable;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
-
-import static hudson.plugins.analysis.util.ThresholdValidator.*;
 
 import hudson.plugins.analysis.util.model.AnnotationProvider;
 import hudson.plugins.analysis.util.model.Priority;
@@ -48,7 +48,7 @@ public abstract class AbstractHealthDescriptor implements HealthDescriptor {
         thresholds = new Thresholds();
         healthy = StringUtils.EMPTY;
         unHealthy = StringUtils.EMPTY;
-        priority = Priority.LOW;
+        priority = Priority.NONE;
     }
 
     @Override @Exported

--- a/src/main/java/hudson/plugins/analysis/core/BuildResult.java
+++ b/src/main/java/hudson/plugins/analysis/core/BuildResult.java
@@ -1273,7 +1273,7 @@ public abstract class BuildResult implements ModelObject, Serializable, Annotati
         }
         else if (useDeltaValues) {
             buildResult = resultEvaluator.evaluateBuildResult(messages, thresholds, getAnnotations(),
-                    getDelta(), getHighDelta(), getNormalDelta(), getLowDelta(), getNoneDelta());
+                    getDelta(), getHighDelta(), getNormalDelta(), getLowDelta());
         }
         else {
             buildResult = resultEvaluator.evaluateBuildResult(messages, thresholds,

--- a/src/main/java/hudson/plugins/analysis/core/BuildResult.java
+++ b/src/main/java/hudson/plugins/analysis/core/BuildResult.java
@@ -465,6 +465,9 @@ public abstract class BuildResult implements ModelObject, Serializable, Annotati
             errors = new ArrayList<String>();
         }
         try {
+            if (none != null) {
+                noneWarnings = Integer.valueOf(none);
+            }
             if (low != null) {
                 lowWarnings = Integer.valueOf(low);
             }
@@ -948,7 +951,7 @@ public abstract class BuildResult implements ModelObject, Serializable, Annotati
      * @return the number of warnings with none priority
      */
     @Exported
-    public int getNumberOfNoPriorityWarnings() {
+    public int getNumberOfNonePriorityWarnings() {
         return noneWarnings;
     }
 
@@ -1716,6 +1719,9 @@ public abstract class BuildResult implements ModelObject, Serializable, Annotati
     @Deprecated
     @java.lang.SuppressWarnings("unused")
     private transient Map<String, MavenModule> emptyModules; // NOPMD
+    @Deprecated
+    @java.lang.SuppressWarnings("all")
+    protected transient String none;
     @Deprecated
     @java.lang.SuppressWarnings("all")
     protected transient String low;

--- a/src/main/java/hudson/plugins/analysis/core/BuildResult.java
+++ b/src/main/java/hudson/plugins/analysis/core/BuildResult.java
@@ -114,8 +114,6 @@ public abstract class BuildResult implements ModelObject, Serializable, Annotati
 
     /** Difference between this and the previous build. */
     private int delta;
-    /** Difference between this and the previous build (Priority none). */
-    private int noneDelta;
     /** Difference between this and the previous build (Priority low). */
     private int lowDelta;
     /** Difference between this and the previous build (Priority normal). */
@@ -284,7 +282,6 @@ public abstract class BuildResult implements ModelObject, Serializable, Annotati
         AnnotationContainer referenceResult = history.getReferenceAnnotations();
 
         delta = result.getNumberOfAnnotations() - referenceResult.getNumberOfAnnotations();
-        noneDelta = computeDelta(result, referenceResult, Priority.NONE);
         lowDelta = computeDelta(result, referenceResult, Priority.LOW);
         normalDelta = computeDelta(result, referenceResult, Priority.NORMAL);
         highDelta = computeDelta(result, referenceResult, Priority.HIGH);
@@ -899,14 +896,6 @@ public abstract class BuildResult implements ModelObject, Serializable, Annotati
         return delta;
     }
 
-    /**
-     * Returns the none delta.
-     *
-     * @return the delta
-     */
-    public int getNoneDelta() {
-        return noneDelta;
-    }
 
     /**
      * Returns the high delta.

--- a/src/main/java/hudson/plugins/analysis/core/BuildResultEvaluator.java
+++ b/src/main/java/hudson/plugins/analysis/core/BuildResultEvaluator.java
@@ -69,6 +69,8 @@ public class BuildResultEvaluator {
      *            delta between this build and reference build (priority normal)
      * @param lowDelta
      *            delta between this build and reference build (priority low)
+     * @param noneDelta
+     *            delta between this build and reference build (priority none)
      * @param allAnnotations
      *            all annotations
      * @return the build result
@@ -113,14 +115,14 @@ public class BuildResultEvaluator {
             return Result.FAILURE;
         }
         if (check(logger, newAnnotations, t.failedNewAll,
-                t.failedNewHigh, t.failedNewNormal, t.failedNewLow, false)) {
+                t.failedNewHigh, t.failedNewNormal, t.failedNewLow,t.failedNewNone, false)) {
             return Result.FAILURE;
         }
         if (checkAllWarningsForUnstable(logger, t, allAnnotations)) {
             return Result.UNSTABLE;
         }
         if (check(logger, newAnnotations, t.unstableNewAll,
-                t.unstableNewHigh, t.unstableNewNormal, t.unstableNewLow, false)) {
+                t.unstableNewHigh, t.unstableNewNormal, t.unstableNewLow,t.unstableNewNone, false)) {
             return Result.UNSTABLE;
         }
 
@@ -130,13 +132,13 @@ public class BuildResultEvaluator {
     private boolean checkAllWarningsForUnstable(final StringBuilder logger, final Thresholds t,
             final Collection<? extends FileAnnotation> allAnnotations) {
         return check(logger, allAnnotations, t.unstableTotalAll,
-                t.unstableTotalHigh, t.unstableTotalNormal, t.unstableTotalLow, true);
+                t.unstableTotalHigh, t.unstableTotalNormal, t.unstableTotalLow,t.unstableTotalNone, true);
     }
 
     private boolean checkAllWarningsForFailure(final StringBuilder logger, final Thresholds t,
             final Collection<? extends FileAnnotation> allAnnotations) {
         return check(logger, allAnnotations, t.failedTotalAll,
-                t.failedTotalHigh, t.failedTotalNormal, t.failedTotalLow, true);
+                t.failedTotalHigh, t.failedTotalNormal, t.failedTotalLow,t.failedTotalNone, true);
     }
 
 
@@ -147,8 +149,8 @@ public class BuildResultEvaluator {
     }
 
     private boolean check(final StringBuilder logger, final Collection<? extends FileAnnotation> annotations,
-            final String all, final String high, final String normal, final String low, final boolean isTotals) {
-        if (checkThresholds(logger, annotations, all, isTotals, Priority.HIGH, Priority.NORMAL, Priority.LOW)) {
+            final String all, final String high, final String normal, final String low, final String none, final boolean isTotals) {
+        if (checkThresholds(logger, annotations, all, isTotals, Priority.HIGH, Priority.NORMAL, Priority.LOW, Priority.NONE)) {
             return true;
         }
         if (checkThresholds(logger, annotations, high, isTotals, Priority.HIGH)) {
@@ -160,11 +162,14 @@ public class BuildResultEvaluator {
         if (checkThresholds(logger, annotations, low, isTotals, Priority.LOW)) {
             return true;
         }
+        if (checkThresholds(logger, annotations, none, isTotals, Priority.NONE)) {
+            return true;
+        }
         return false;
     }
 
     private boolean checkFailedNew(final StringBuilder logger, final int delta, final int highDelta, final int normalDelta, final int lowDelta, final int noneDelta, final Thresholds t) {
-        if (checkThresholds(logger, delta, t.failedNewAll, false, Priority.HIGH, Priority.NORMAL, Priority.LOW)) {
+        if (checkThresholds(logger, delta, t.failedNewAll, false, Priority.HIGH, Priority.NORMAL, Priority.LOW, Priority.NONE)) {
             return true;
         }
         if (checkThresholds(logger, highDelta, t.failedNewHigh, false, Priority.HIGH)) {
@@ -176,14 +181,14 @@ public class BuildResultEvaluator {
         if (checkThresholds(logger, lowDelta, t.failedNewLow, false, Priority.LOW)) {
             return true;
         }
-        if (checkThresholds(logger, noneDelta, t.failedNewLow, false, Priority.NONE)) {
+        if (checkThresholds(logger, noneDelta, t.failedNewNone, false, Priority.NONE)) {
             return true;
         }
         return false;
     }
 
     private boolean checkUnstableNew(final StringBuilder logger, final int delta, final int highDelta, final int normalDelta, final int lowDelta, final int noneDelta, final Thresholds t) {
-        if (checkThresholds(logger, delta, t.unstableNewAll, false, Priority.HIGH, Priority.NORMAL, Priority.LOW)) {
+        if (checkThresholds(logger, delta, t.unstableNewAll, false, Priority.HIGH, Priority.NORMAL, Priority.LOW, Priority.NONE)) {
             return true;
         }
         if (checkThresholds(logger, highDelta, t.unstableNewHigh, false, Priority.HIGH)) {
@@ -195,7 +200,7 @@ public class BuildResultEvaluator {
         if (checkThresholds(logger, lowDelta, t.unstableNewLow, false, Priority.LOW)) {
             return true;
         }
-        if (checkThresholds(logger, noneDelta, t.unstableNewLow, false, Priority.NONE)) {
+        if (checkThresholds(logger, noneDelta, t.unstableNewNone, false, Priority.NONE)) {
             return true;
         }
         return false;
@@ -355,10 +360,12 @@ public class BuildResultEvaluator {
      *            delta between this build and reference build (priority normal)
      * @param lowDelta
      *            delta between this build and reference build (priority low)
+     * @param noneDelta
+     *            delta between this build and reference build (priority none)
      * @param allAnnotations
      *            all annotations
      * @return the build result
-     * @deprecated use {@link #evaluateBuildResult(StringBuilder, Thresholds, Collection, int, int, int, int)}
+     * @deprecated use {@link #evaluateBuildResult(StringBuilder, Thresholds, Collection, int, int, int, int, int)}
      */
     @Deprecated
     public Result evaluateBuildResult(final PluginLogger logger, final Thresholds t,

--- a/src/main/java/hudson/plugins/analysis/core/BuildResultEvaluator.java
+++ b/src/main/java/hudson/plugins/analysis/core/BuildResultEvaluator.java
@@ -69,25 +69,23 @@ public class BuildResultEvaluator {
      *            delta between this build and reference build (priority normal)
      * @param lowDelta
      *            delta between this build and reference build (priority low)
-     * @param noneDelta
-     *            delta between this build and reference build (priority none)
      * @param allAnnotations
      *            all annotations
      * @return the build result
      */
     public Result evaluateBuildResult(final StringBuilder logger, final Thresholds t,
             final Collection<? extends FileAnnotation> allAnnotations,
-            final int delta, final int highDelta, final int normalDelta, final int lowDelta, final int noneDelta) {
+            final int delta, final int highDelta, final int normalDelta, final int lowDelta) {
         if (checkAllWarningsForFailure(logger, t, allAnnotations)) {
             return Result.FAILURE;
         }
-        if (checkFailedNew(logger, delta, highDelta, normalDelta, lowDelta,noneDelta, t)) {
+        if (checkFailedNew(logger, delta, highDelta, normalDelta, lowDelta, t)) {
             return Result.FAILURE;
         }
         if (checkAllWarningsForUnstable(logger, t, allAnnotations)) {
             return Result.UNSTABLE;
         }
-        if (checkUnstableNew(logger, delta, highDelta, normalDelta, lowDelta,noneDelta, t)) {
+        if (checkUnstableNew(logger, delta, highDelta, normalDelta, lowDelta, t)) {
             return Result.UNSTABLE;
         }
 
@@ -115,14 +113,14 @@ public class BuildResultEvaluator {
             return Result.FAILURE;
         }
         if (check(logger, newAnnotations, t.failedNewAll,
-                t.failedNewHigh, t.failedNewNormal, t.failedNewLow,t.failedNewNone, false)) {
+                t.failedNewHigh, t.failedNewNormal, t.failedNewLow, false)) {
             return Result.FAILURE;
         }
         if (checkAllWarningsForUnstable(logger, t, allAnnotations)) {
             return Result.UNSTABLE;
         }
         if (check(logger, newAnnotations, t.unstableNewAll,
-                t.unstableNewHigh, t.unstableNewNormal, t.unstableNewLow,t.unstableNewNone, false)) {
+                t.unstableNewHigh, t.unstableNewNormal, t.unstableNewLow, false)) {
             return Result.UNSTABLE;
         }
 
@@ -132,13 +130,13 @@ public class BuildResultEvaluator {
     private boolean checkAllWarningsForUnstable(final StringBuilder logger, final Thresholds t,
             final Collection<? extends FileAnnotation> allAnnotations) {
         return check(logger, allAnnotations, t.unstableTotalAll,
-                t.unstableTotalHigh, t.unstableTotalNormal, t.unstableTotalLow,t.unstableTotalNone, true);
+                t.unstableTotalHigh, t.unstableTotalNormal, t.unstableTotalLow, true);
     }
 
     private boolean checkAllWarningsForFailure(final StringBuilder logger, final Thresholds t,
             final Collection<? extends FileAnnotation> allAnnotations) {
         return check(logger, allAnnotations, t.failedTotalAll,
-                t.failedTotalHigh, t.failedTotalNormal, t.failedTotalLow,t.failedTotalNone, true);
+                t.failedTotalHigh, t.failedTotalNormal, t.failedTotalLow, true);
     }
 
 
@@ -149,8 +147,8 @@ public class BuildResultEvaluator {
     }
 
     private boolean check(final StringBuilder logger, final Collection<? extends FileAnnotation> annotations,
-            final String all, final String high, final String normal, final String low, final String none, final boolean isTotals) {
-        if (checkThresholds(logger, annotations, all, isTotals, Priority.HIGH, Priority.NORMAL, Priority.LOW, Priority.NONE)) {
+            final String all, final String high, final String normal, final String low, final boolean isTotals) {
+        if (checkThresholds(logger, annotations, all, isTotals, Priority.HIGH, Priority.NORMAL, Priority.LOW)) {
             return true;
         }
         if (checkThresholds(logger, annotations, high, isTotals, Priority.HIGH)) {
@@ -162,14 +160,11 @@ public class BuildResultEvaluator {
         if (checkThresholds(logger, annotations, low, isTotals, Priority.LOW)) {
             return true;
         }
-        if (checkThresholds(logger, annotations, none, isTotals, Priority.NONE)) {
-            return true;
-        }
         return false;
     }
 
-    private boolean checkFailedNew(final StringBuilder logger, final int delta, final int highDelta, final int normalDelta, final int lowDelta, final int noneDelta, final Thresholds t) {
-        if (checkThresholds(logger, delta, t.failedNewAll, false, Priority.HIGH, Priority.NORMAL, Priority.LOW, Priority.NONE)) {
+    private boolean checkFailedNew(final StringBuilder logger, final int delta, final int highDelta, final int normalDelta, final int lowDelta,  final Thresholds t) {
+        if (checkThresholds(logger, delta, t.failedNewAll, false, Priority.HIGH, Priority.NORMAL, Priority.LOW)) {
             return true;
         }
         if (checkThresholds(logger, highDelta, t.failedNewHigh, false, Priority.HIGH)) {
@@ -181,14 +176,11 @@ public class BuildResultEvaluator {
         if (checkThresholds(logger, lowDelta, t.failedNewLow, false, Priority.LOW)) {
             return true;
         }
-        if (checkThresholds(logger, noneDelta, t.failedNewNone, false, Priority.NONE)) {
-            return true;
-        }
         return false;
     }
 
-    private boolean checkUnstableNew(final StringBuilder logger, final int delta, final int highDelta, final int normalDelta, final int lowDelta, final int noneDelta, final Thresholds t) {
-        if (checkThresholds(logger, delta, t.unstableNewAll, false, Priority.HIGH, Priority.NORMAL, Priority.LOW, Priority.NONE)) {
+    private boolean checkUnstableNew(final StringBuilder logger, final int delta, final int highDelta, final int normalDelta, final int lowDelta, final Thresholds t) {
+        if (checkThresholds(logger, delta, t.unstableNewAll, false, Priority.HIGH, Priority.NORMAL, Priority.LOW)) {
             return true;
         }
         if (checkThresholds(logger, highDelta, t.unstableNewHigh, false, Priority.HIGH)) {
@@ -198,9 +190,6 @@ public class BuildResultEvaluator {
             return true;
         }
         if (checkThresholds(logger, lowDelta, t.unstableNewLow, false, Priority.LOW)) {
-            return true;
-        }
-        if (checkThresholds(logger, noneDelta, t.unstableNewNone, false, Priority.NONE)) {
             return true;
         }
         return false;
@@ -360,19 +349,17 @@ public class BuildResultEvaluator {
      *            delta between this build and reference build (priority normal)
      * @param lowDelta
      *            delta between this build and reference build (priority low)
-     * @param noneDelta
-     *            delta between this build and reference build (priority none)
      * @param allAnnotations
      *            all annotations
      * @return the build result
-     * @deprecated use {@link #evaluateBuildResult(StringBuilder, Thresholds, Collection, int, int, int, int, int)}
+     * @deprecated use {@link #evaluateBuildResult(StringBuilder, Thresholds, Collection, int, int,  int, int)}
      */
     @Deprecated
     public Result evaluateBuildResult(final PluginLogger logger, final Thresholds t,
             final Collection<? extends FileAnnotation> allAnnotations,
-            final int delta, final int highDelta, final int normalDelta, final int lowDelta, final int noneDelta) {
+            final int delta, final int highDelta, final int normalDelta, final int lowDelta) {
         StringBuilder log = new StringBuilder();
-        Result result = evaluateBuildResult(log, t, allAnnotations, delta, highDelta, normalDelta, lowDelta, noneDelta);
+        Result result = evaluateBuildResult(log, t, allAnnotations, delta, highDelta, normalDelta, lowDelta);
         logger.log(log.toString());
         return result;
     }

--- a/src/main/java/hudson/plugins/analysis/core/BuildResultEvaluator.java
+++ b/src/main/java/hudson/plugins/analysis/core/BuildResultEvaluator.java
@@ -1,10 +1,11 @@
 package hudson.plugins.analysis.core;
 
-import java.util.Collection;
-
 import static hudson.plugins.analysis.util.ThresholdValidator.*;
 
+import java.util.Collection;
+
 import hudson.model.Result;
+
 import hudson.plugins.analysis.Messages;
 import hudson.plugins.analysis.util.PluginLogger;
 import hudson.plugins.analysis.util.model.FileAnnotation;
@@ -74,17 +75,17 @@ public class BuildResultEvaluator {
      */
     public Result evaluateBuildResult(final StringBuilder logger, final Thresholds t,
             final Collection<? extends FileAnnotation> allAnnotations,
-            final int delta, final int highDelta, final int normalDelta, final int lowDelta) {
+            final int delta, final int highDelta, final int normalDelta, final int lowDelta, final int noneDelta) {
         if (checkAllWarningsForFailure(logger, t, allAnnotations)) {
             return Result.FAILURE;
         }
-        if (checkFailedNew(logger, delta, highDelta, normalDelta, lowDelta, t)) {
+        if (checkFailedNew(logger, delta, highDelta, normalDelta, lowDelta,noneDelta, t)) {
             return Result.FAILURE;
         }
         if (checkAllWarningsForUnstable(logger, t, allAnnotations)) {
             return Result.UNSTABLE;
         }
-        if (checkUnstableNew(logger, delta, highDelta, normalDelta, lowDelta, t)) {
+        if (checkUnstableNew(logger, delta, highDelta, normalDelta, lowDelta,noneDelta, t)) {
             return Result.UNSTABLE;
         }
 
@@ -162,7 +163,7 @@ public class BuildResultEvaluator {
         return false;
     }
 
-    private boolean checkFailedNew(final StringBuilder logger, final int delta, final int highDelta, final int normalDelta, final int lowDelta, final Thresholds t) {
+    private boolean checkFailedNew(final StringBuilder logger, final int delta, final int highDelta, final int normalDelta, final int lowDelta, final int noneDelta, final Thresholds t) {
         if (checkThresholds(logger, delta, t.failedNewAll, false, Priority.HIGH, Priority.NORMAL, Priority.LOW)) {
             return true;
         }
@@ -175,10 +176,13 @@ public class BuildResultEvaluator {
         if (checkThresholds(logger, lowDelta, t.failedNewLow, false, Priority.LOW)) {
             return true;
         }
+        if (checkThresholds(logger, noneDelta, t.failedNewLow, false, Priority.NONE)) {
+            return true;
+        }
         return false;
     }
 
-    private boolean checkUnstableNew(final StringBuilder logger, final int delta, final int highDelta, final int normalDelta, final int lowDelta, final Thresholds t) {
+    private boolean checkUnstableNew(final StringBuilder logger, final int delta, final int highDelta, final int normalDelta, final int lowDelta, final int noneDelta, final Thresholds t) {
         if (checkThresholds(logger, delta, t.unstableNewAll, false, Priority.HIGH, Priority.NORMAL, Priority.LOW)) {
             return true;
         }
@@ -189,6 +193,9 @@ public class BuildResultEvaluator {
             return true;
         }
         if (checkThresholds(logger, lowDelta, t.unstableNewLow, false, Priority.LOW)) {
+            return true;
+        }
+        if (checkThresholds(logger, noneDelta, t.unstableNewLow, false, Priority.NONE)) {
             return true;
         }
         return false;
@@ -356,9 +363,9 @@ public class BuildResultEvaluator {
     @Deprecated
     public Result evaluateBuildResult(final PluginLogger logger, final Thresholds t,
             final Collection<? extends FileAnnotation> allAnnotations,
-            final int delta, final int highDelta, final int normalDelta, final int lowDelta) {
+            final int delta, final int highDelta, final int normalDelta, final int lowDelta, final int noneDelta) {
         StringBuilder log = new StringBuilder();
-        Result result = evaluateBuildResult(log, t, allAnnotations, delta, highDelta, normalDelta, lowDelta);
+        Result result = evaluateBuildResult(log, t, allAnnotations, delta, highDelta, normalDelta, lowDelta, noneDelta);
         logger.log(log.toString());
         return result;
     }

--- a/src/main/java/hudson/plugins/analysis/core/Thresholds.java
+++ b/src/main/java/hudson/plugins/analysis/core/Thresholds.java
@@ -1,5 +1,7 @@
 package hudson.plugins.analysis.core;
 
+import static hudson.plugins.analysis.util.ThresholdValidator.*;
+
 import java.io.Serializable;
 
 import org.apache.commons.lang.StringUtils;
@@ -7,7 +9,6 @@ import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import static hudson.plugins.analysis.util.ThresholdValidator.*;
 
 /**
  * Data object that simply stores the thresholds.
@@ -28,6 +29,8 @@ public class Thresholds implements Serializable {
     @Exported
     public String unstableTotalLow = StringUtils.EMPTY;
     @Exported
+    public String unstableTotalNone = StringUtils.EMPTY;
+    @Exported
     public String unstableNewAll = StringUtils.EMPTY;
     @Exported
     public String unstableNewHigh = StringUtils.EMPTY;
@@ -35,6 +38,8 @@ public class Thresholds implements Serializable {
     public String unstableNewNormal = StringUtils.EMPTY;
     @Exported
     public String unstableNewLow = StringUtils.EMPTY;
+    @Exported
+    public String unstableNewNone = StringUtils.EMPTY;
     @Exported
     public String failedTotalAll = StringUtils.EMPTY;
     @Exported
@@ -44,6 +49,8 @@ public class Thresholds implements Serializable {
     @Exported
     public String failedTotalLow = StringUtils.EMPTY;
     @Exported
+    public String failedTotalNone = StringUtils.EMPTY;
+    @Exported
     public String failedNewAll = StringUtils.EMPTY;
     @Exported
     public String failedNewHigh = StringUtils.EMPTY;
@@ -51,6 +58,8 @@ public class Thresholds implements Serializable {
     public String failedNewNormal = StringUtils.EMPTY;
     @Exported
     public String failedNewLow = StringUtils.EMPTY;
+    @Exported
+    public String failedNewNone = StringUtils.EMPTY;
 
     /**
      * Returns whether at least one of the thresholds is set.
@@ -63,18 +72,22 @@ public class Thresholds implements Serializable {
         || isValid(unstableTotalHigh)
         || isValid(unstableTotalNormal)
         || isValid(unstableTotalLow)
+        || isValid(unstableTotalNone)
         || isValid(unstableNewAll)
         || isValid(unstableNewHigh)
         || isValid(unstableNewNormal)
         || isValid(unstableNewLow)
+         || isValid(unstableNewNone)
         || isValid(failedTotalAll)
         || isValid(failedTotalHigh)
         || isValid(failedTotalNormal)
         || isValid(failedTotalLow)
+        || isValid(failedTotalNone)
         || isValid(failedNewAll)
         || isValid(failedNewHigh)
         || isValid(failedNewNormal)
-        || isValid(failedNewLow);
+        || isValid(failedNewLow)
+        || isValid(failedNewNone);
     }
 
     /**

--- a/src/main/java/hudson/plugins/analysis/core/Thresholds.java
+++ b/src/main/java/hudson/plugins/analysis/core/Thresholds.java
@@ -29,8 +29,6 @@ public class Thresholds implements Serializable {
     @Exported
     public String unstableTotalLow = StringUtils.EMPTY;
     @Exported
-    public String unstableTotalNone = StringUtils.EMPTY;
-    @Exported
     public String unstableNewAll = StringUtils.EMPTY;
     @Exported
     public String unstableNewHigh = StringUtils.EMPTY;
@@ -38,8 +36,6 @@ public class Thresholds implements Serializable {
     public String unstableNewNormal = StringUtils.EMPTY;
     @Exported
     public String unstableNewLow = StringUtils.EMPTY;
-    @Exported
-    public String unstableNewNone = StringUtils.EMPTY;
     @Exported
     public String failedTotalAll = StringUtils.EMPTY;
     @Exported
@@ -49,8 +45,6 @@ public class Thresholds implements Serializable {
     @Exported
     public String failedTotalLow = StringUtils.EMPTY;
     @Exported
-    public String failedTotalNone = StringUtils.EMPTY;
-    @Exported
     public String failedNewAll = StringUtils.EMPTY;
     @Exported
     public String failedNewHigh = StringUtils.EMPTY;
@@ -58,8 +52,6 @@ public class Thresholds implements Serializable {
     public String failedNewNormal = StringUtils.EMPTY;
     @Exported
     public String failedNewLow = StringUtils.EMPTY;
-    @Exported
-    public String failedNewNone = StringUtils.EMPTY;
 
     /**
      * Returns whether at least one of the thresholds is set.
@@ -72,22 +64,18 @@ public class Thresholds implements Serializable {
         || isValid(unstableTotalHigh)
         || isValid(unstableTotalNormal)
         || isValid(unstableTotalLow)
-        || isValid(unstableTotalNone)
         || isValid(unstableNewAll)
         || isValid(unstableNewHigh)
         || isValid(unstableNewNormal)
         || isValid(unstableNewLow)
-         || isValid(unstableNewNone)
         || isValid(failedTotalAll)
         || isValid(failedTotalHigh)
         || isValid(failedTotalNormal)
         || isValid(failedTotalLow)
-        || isValid(failedTotalNone)
         || isValid(failedNewAll)
         || isValid(failedNewHigh)
         || isValid(failedNewNormal)
-        || isValid(failedNewLow)
-        || isValid(failedNewNone);
+        || isValid(failedNewLow);
     }
 
     /**

--- a/src/main/java/hudson/plugins/analysis/graph/PriorityGraph.java
+++ b/src/main/java/hudson/plugins/analysis/graph/PriorityGraph.java
@@ -1,6 +1,6 @@
 package hudson.plugins.analysis.graph;
 
-import java.awt.*;
+import java.awt.Color;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -38,6 +38,7 @@ public class PriorityGraph extends CategoryBuildResultGraph {
     @Override
     protected List<Integer> computeSeries(final BuildResult current) {
         List<Integer> series = new ArrayList<Integer>();
+        series.add(current.getNumberOfAnnotations(Priority.NONE));
         series.add(current.getNumberOfAnnotations(Priority.LOW));
         series.add(current.getNumberOfAnnotations(Priority.NORMAL));
         series.add(current.getNumberOfAnnotations(Priority.HIGH));
@@ -64,9 +65,11 @@ public class PriorityGraph extends CategoryBuildResultGraph {
                     @Override
             protected String getShortDescription(final int row) {
                 if (row == 0) {
+                    return Messages.Trend_PriorityNone();
+                } else if (row == 1) {
                     return Messages.Trend_PriorityLow();
                 }
-                else if (row == 1) {
+                else if (row == 2) {
                     return Messages.Trend_PriorityNormal();
                 }
                 else {
@@ -96,9 +99,11 @@ public class PriorityGraph extends CategoryBuildResultGraph {
         @Override
         protected String getDetailUrl(final int row) {
             if (row == 0) {
+                return Priority.NONE.name();
+            } else if (row == 1) {
                 return Priority.LOW.name();
             }
-            else if (row == 1) {
+            else if (row == 2) {
                 return Priority.NORMAL.name();
             }
             else {

--- a/src/main/java/hudson/plugins/analysis/util/model/AnnotationContainer.java
+++ b/src/main/java/hudson/plugins/analysis/util/model/AnnotationContainer.java
@@ -431,6 +431,25 @@ public abstract class AnnotationContainer implements AnnotationProvider, Seriali
                 getLowAnnotations());
     }
 
+    /**
+     * Returns the annotations with {@link Priority#NONE}.
+     *
+     * @return the annotations with {@link Priority#NONE}
+     */
+    public final Set<FileAnnotation> getNoneAnnotations() {
+        return getAnnotations(Priority.NONE);
+    }
+
+    /**
+     * Returns the annotations with {@link Priority#NONE}.
+     *
+     * @return the annotations with {@link Priority#NONE}
+     */
+    public DefaultAnnotationContainer getNone() {
+        return new DefaultAnnotationContainer(Priority.NONE.getLocalizedString(),
+                getNoneAnnotations());
+    }
+
     @Override
     public final Set<FileAnnotation> getAnnotations(final String priority) {
         return getAnnotations(getPriority(priority));
@@ -450,6 +469,15 @@ public abstract class AnnotationContainer implements AnnotationProvider, Seriali
     @Override
     public int getNumberOfAnnotations() {
         return annotations.size();
+    }
+
+    /**
+     * Gets the number of annotations with priority none.
+     *
+     * @return the number of annotations with priority none
+     */
+    public int getNumberOfNoneAnnotations() {
+        return getNoneAnnotations().size();
     }
 
     /**
@@ -883,6 +911,15 @@ public abstract class AnnotationContainer implements AnnotationProvider, Seriali
      */
     public Priority getLowPriority() {
         return Priority.LOW;
+    }
+
+    /**
+     * Returns {@link Priority#NONE}.
+     *
+     * @return {@link Priority#NONE}
+     */
+    public Priority getNonePriority() {
+        return Priority.NONE;
     }
 
     @Override

--- a/src/main/java/hudson/plugins/analysis/util/model/AnnotationsLabelProvider.java
+++ b/src/main/java/hudson/plugins/analysis/util/model/AnnotationsLabelProvider.java
@@ -67,4 +67,8 @@ public class AnnotationsLabelProvider implements Serializable {
     public String getLow() {
         return Messages.BuildResult_Tab_Low();
     }
+
+    public String getNone() {
+        return Messages.BuildResult_Tab_None();
+    }
 }

--- a/src/main/java/hudson/plugins/analysis/util/model/Priority.java
+++ b/src/main/java/hudson/plugins/analysis/util/model/Priority.java
@@ -21,7 +21,9 @@ public enum Priority {
     /** Normal priority. */
     NORMAL,
     /** Low priority. */
-    LOW;
+    LOW,
+    /** No priority. Informational annotations */
+    NONE;
 
     /**
      * Converts a String priority to an actual enumeration value.
@@ -62,6 +64,9 @@ public enum Priority {
         if (this == LOW) {
             return Messages.Priority_Low();
         }
+        if (this == NONE) {
+            return Messages.Priority_None();
+        }
         return Messages.Priority_Normal();
     }
 
@@ -76,6 +81,9 @@ public enum Priority {
         }
         if (this == Priority.LOW) {
             return Messages.LowPriority();
+        }
+        if (this == Priority.NONE) {
+            return Messages.NonePriority();
         }
         return Messages.NormalPriority();
     }
@@ -97,6 +105,11 @@ public enum Priority {
         if (minimumPriority == Priority.LOW) {
             priorities.add(Priority.NORMAL);
             priorities.add(Priority.LOW);
+        }
+        if (minimumPriority == Priority.NONE) {
+            priorities.add(Priority.NORMAL);
+            priorities.add(Priority.LOW);
+            priorities.add(Priority.NONE);
         }
         return priorities;
     }

--- a/src/main/java/hudson/plugins/analysis/views/PriorityDetailFactory.java
+++ b/src/main/java/hudson/plugins/analysis/views/PriorityDetailFactory.java
@@ -60,7 +60,7 @@ public class PriorityDetailFactory {
      * @return the priority detail
      */
     public PrioritiesDetail create(final String priority, @Nonnull final Run<?, ?> owner, final AnnotationContainer container, final String defaultEncoding, final String header) {
-        if (owner instanceof AbstractBuild && Compatibility.isOverridden(PriorityDetailFactory.class, getClass(), "create", 
+        if (owner instanceof AbstractBuild && Compatibility.isOverridden(PriorityDetailFactory.class, getClass(), "create",
                 String.class, AbstractBuild.class, AnnotationContainer.class, String.class, String.class)) {
             return create(priority, (AbstractBuild<?, ?>) owner, container, defaultEncoding, header);
         }
@@ -73,6 +73,9 @@ public class PriorityDetailFactory {
             }
             else if (Priority.LOW.toString().equalsIgnoreCase(priority)) {
                 return createPrioritiesDetail(Priority.LOW, owner, container, defaultEncoding, header);
+            }
+            else if (Priority.NONE.toString().equalsIgnoreCase(priority)) {
+                return createPrioritiesDetail(Priority.NONE, owner, container, defaultEncoding, header);
             }
             throw new IllegalArgumentException("Wrong priority provided: " + priority);
         }
@@ -95,7 +98,7 @@ public class PriorityDetailFactory {
      */
     protected PrioritiesDetail createPrioritiesDetail(final Priority priority, @Nonnull final Run<?, ?> owner, final AnnotationContainer container,
             final String defaultEncoding, final String header) {
-        if (owner instanceof AbstractBuild && Compatibility.isOverridden(PriorityDetailFactory.class, getClass(), "createPrioritiesDetail", 
+        if (owner instanceof AbstractBuild && Compatibility.isOverridden(PriorityDetailFactory.class, getClass(), "createPrioritiesDetail",
                 Priority.class, AbstractBuild.class, AnnotationContainer.class, String.class, String.class)) {
             return createPrioritiesDetail(priority, (AbstractBuild<?, ?>) owner, container, defaultEncoding, header);
         }

--- a/src/main/java/hudson/plugins/analysis/views/WarningsCountColumn.java
+++ b/src/main/java/hudson/plugins/analysis/views/WarningsCountColumn.java
@@ -3,11 +3,13 @@ package hudson.plugins.analysis.views;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import hudson.model.Job;
+
 import hudson.plugins.analysis.Messages;
 import hudson.plugins.analysis.core.AbstractProjectAction;
 import hudson.plugins.analysis.core.BuildResult;
 import hudson.plugins.analysis.util.HtmlPrinter;
 import hudson.plugins.analysis.util.model.Priority;
+
 import hudson.views.ListViewColumn;
 
 /**
@@ -108,6 +110,7 @@ public abstract class WarningsCountColumn<T extends AbstractProjectAction<?>> ex
             print(printer, Priority.HIGH, result.getNumberOfHighPriorityWarnings());
             print(printer, Priority.NORMAL, result.getNumberOfNormalPriorityWarnings());
             print(printer, Priority.LOW, result.getNumberOfLowPriorityWarnings());
+            print(printer, Priority.NONE, result.getNumberOfNonePriorityWarnings());
         }
         else {
             return Messages.Column_NoResults();

--- a/src/main/resources/hudson/plugins/analysis/Messages.properties
+++ b/src/main/resources/hudson/plugins/analysis/Messages.properties
@@ -6,6 +6,7 @@ ConsoleLog.Name=Console output
 Trend.PriorityHigh=(high priority)
 Trend.PriorityNormal=(normal priority)
 Trend.PriorityLow=(low priority)
+Trend.PriorityNone=(no priority)
 
 Trend.Fixed=(fixed)
 Trend.New=(new)
@@ -13,6 +14,7 @@ Trend.New=(new)
 Priority.High=High
 Priority.Normal=Normal
 Priority.Low=Low
+Priority.None=None
 
 Errors=Errors
 
@@ -21,6 +23,7 @@ ReferenceBuild=Reference build
 HighPriority=High Priority
 LowPriority=Low Priority
 NormalPriority=Normal Priority
+NonePriority=No Priority
 
 ModuleDetail.header=Module
 PathDetail.header=Source Folder

--- a/src/main/resources/hudson/plugins/analysis/Messages.properties
+++ b/src/main/resources/hudson/plugins/analysis/Messages.properties
@@ -111,3 +111,4 @@ BuildResult.Tab.Fixed=Fixed
 BuildResult.Tab.High=High
 BuildResult.Tab.Normal=Normal
 BuildResult.Tab.Low=Low
+BuildResult.Tab.None=None

--- a/src/main/resources/hudson/plugins/analysis/views/TabDetail/none.jelly
+++ b/src/main/resources/hudson/plugins/analysis/views/TabDetail/none.jelly
@@ -1,0 +1,9 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
+  xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
+  xmlns:i="jelly:fmt">
+
+  <j:set var="annotations" value="${it.container.none}" />
+  <st:include page="${it.details}" />
+
+</j:jelly>

--- a/src/main/resources/result/main.jelly
+++ b/src/main/resources/result/main.jelly
@@ -214,6 +214,11 @@
             background: #729FCF;
             background-image:url(${resURL}/plugin/analysis-core/icons/clearpixel.gif);
         }
+        
+        .priority-none {
+            background: #ADADAD;
+            background-image:url(${resURL}/plugin/analysis-core/icons/clearpixel.gif);
+        }
 
     </style>
 

--- a/src/main/resources/result/main.jelly
+++ b/src/main/resources/result/main.jelly
@@ -112,7 +112,7 @@
     </j:if>
     <j:if test="${it.container.noneAnnotations.size() > 0 and it.container.noneAnnotations.size() != it.container.numberOfAnnotations}">
         YAHOO.plugin.Dispatcher.delegate (new YAHOO.widget.Tab({
-            label: '<div id="low">${l.none}</div>',
+            label: '<div id="none">${l.none}</div>',
             dataSrc: 'tab.none/',
             cacheData: true,
             active: false

--- a/src/main/resources/result/main.jelly
+++ b/src/main/resources/result/main.jelly
@@ -110,6 +110,14 @@
             active: false
         }), myTabs);
     </j:if>
+    <j:if test="${it.container.noneAnnotations.size() > 0 and it.container.noneAnnotations.size() != it.container.numberOfAnnotations}">
+        YAHOO.plugin.Dispatcher.delegate (new YAHOO.widget.Tab({
+            label: '<div id="low">${l.none}</div>',
+            dataSrc: 'tab.none/',
+            cacheData: true,
+            active: false
+        }), myTabs);
+    </j:if>
 
       myTabs.set('activeIndex', 0);
 

--- a/src/main/resources/result/priority-graph.jelly
+++ b/src/main/resources/result/priority-graph.jelly
@@ -8,6 +8,7 @@
   <j:set var="high" value="${container.numberOfHighAnnotations}" />
   <j:set var="normal" value="${container.numberOfNormalAnnotations}" />
   <j:set var="low" value="${container.numberOfLowAnnotations}" />
+   <j:set var="none" value="${container.numberOfNoAnnotations}" />
 
   <table cellpadding="0" cellspacing="0" width="100%" tooltip="${container.toolTip}">
     <tr style="height:10;padding:0">
@@ -23,7 +24,11 @@
         <td class="priority-low" style="width:${low / max * 100}%">
         </td>
       </j:if>
-      <td style="width:${ (max - high - normal - low) / max * 100}%">
+      <j:if test="${none > 0}">
+        <td class="priority-none" style="width:${none / max * 100}%">
+        </td>
+      </j:if>
+      <td style="width:${ (max - high - normal - low - none) / max * 100}%">
       </td>
     </tr>
   </table>

--- a/src/main/resources/result/priority-graph.jelly
+++ b/src/main/resources/result/priority-graph.jelly
@@ -8,7 +8,7 @@
   <j:set var="high" value="${container.numberOfHighAnnotations}" />
   <j:set var="normal" value="${container.numberOfNormalAnnotations}" />
   <j:set var="low" value="${container.numberOfLowAnnotations}" />
-   <j:set var="none" value="${container.numberOfNoAnnotations}" />
+   <j:set var="none" value="${container.numberOfNoneAnnotations}" />
 
   <table cellpadding="0" cellspacing="0" width="100%" tooltip="${container.toolTip}">
     <tr style="height:10;padding:0">


### PR DESCRIPTION
Having warnings with no priorities would be helpful to show informational "warnings" that do not require any work to be done by the User, but would allow us to provide them with information about their code
