### PR TITLE
Improve AnnotationDifferencer performance

### DIFF
--- a/src/main/java/hudson/plugins/analysis/core/AnnotationDifferencer.java
+++ b/src/main/java/hudson/plugins/analysis/core/AnnotationDifferencer.java
@@ -40,7 +40,7 @@ public final class AnnotationDifferencer {
     private static Set<FileAnnotation> difference(
             final Set<FileAnnotation> target, final Set<FileAnnotation> other) {
         Set<FileAnnotation> difference = Sets.newHashSet(target);
-        difference.removeAll(other);
+        difference.removeAll(Sets.newHashSet(other));
         return difference;
     }
 


### PR DESCRIPTION
I am trying to use this plugin along with the [Checkstyle](https://wiki.jenkins-ci.org/display/JENKINS/Checkstyle+Plugin) plugin to parse rubocop warnings. The Checkstyle XML output output file is about 23 MB since I have a lot of rubocop warnings currently in my project.

Based on feedback from [this jenkins bug](https://issues.jenkins-ci.org/browse/JENKINS-2978) and [stack overflow](http://stackoverflow.com/questions/28671903/hashset-removeall-method-is-surprisingly-slow) I made this simple change, that should increase performance significantly for certain scenarios.

Basically `removeAll` works differently for HashSets or Collections because it calls `contains` in some edge cases.
