### PR TITLE
Using jobs absoluteUrl instead of shouldUrl to fork perfectly with folders

### DIFF
--- a/src/main/java/hudson/plugins/analysis/dashboard/AbstractWarningsTablePortlet.java
+++ b/src/main/java/hudson/plugins/analysis/dashboard/AbstractWarningsTablePortlet.java
@@ -192,7 +192,7 @@ public abstract class AbstractWarningsTablePortlet extends AbstractPortlet {
                 int numberOfAnnotations = result.getNumberOfAnnotations();
                 String value;
                 if (numberOfAnnotations > 0) {
-                    value = String.format("<a href=\"%s%s\">%d</a>", job.getShortUrl(), action.getUrlName(), numberOfAnnotations);
+                    value = String.format("<a href=\"%s%s\">%d</a>", job.getAbsoluteUrl(), action.getUrlName(), numberOfAnnotations);
                 }
                 else {
                     value = String.valueOf(numberOfAnnotations);


### PR DESCRIPTION
In case of multibranch pipelines which use Folders plugin and Folders plugin itself, job urls are not correctly reflect real action urls. 

This PR allows for the action urls to be generated correctly by means of using job absolute urls instead of short ones. 