### PR TITLE
JENKINS-40083 AbstractProjectAction.getLastFinishedBuild is @Exported…

### DIFF
--- a/src/main/java/hudson/plugins/analysis/core/AbstractProjectAction.java
+++ b/src/main/java/hudson/plugins/analysis/core/AbstractProjectAction.java
@@ -483,7 +483,8 @@ public abstract class AbstractProjectAction<T extends ResultAction<?>> implement
      */
     @Deprecated @CheckForNull @Exported
     public AbstractBuild<?, ?> getLastFinishedBuild() {
-        return (AbstractBuild<?, ?>) getLastFinishedRun();
+        Run<?, ?> lastFinishedRun = getLastFinishedRun();
+        return lastFinishedRun instanceof AbstractBuild ? (AbstractBuild<?, ?>) lastFinishedRun : null;
     }
 
     /**


### PR DESCRIPTION
`AbstractProjectAction.getLastFinishedBuild` is `@Exported` which means it will be rendered in any Blue Ocean REST response. If the "Build" is not instanceof `AbstractBuild` a `ClassCastException` will be thrown when `getLastFinishedBuild()` is serialized.

I believe this will also break Jenkins' own remote API.

This problem is causing [Blue Ocean to not render Pipelines for users of analysis plugins and Pipeline jobs](https://issues.jenkins-ci.org/browse/JENKINS-40083).

@uhafner mate would we be able to get this into a bug fix release soon please?