### PR TITLE
Remove CanContinue flag from postbuild jobs

### DIFF
--- a/src/main/java/hudson/plugins/analysis/core/HealthAwareRecorder.java
+++ b/src/main/java/hudson/plugins/analysis/core/HealthAwareRecorder.java
@@ -291,12 +291,7 @@ public abstract class HealthAwareRecorder extends Recorder implements HealthDesc
     public final void perform(final Run<?, ?> run, final FilePath workspace, final Launcher launcher, final TaskListener listener)
             throws InterruptedException, IOException {
         PluginLogger logger = new LoggerFactory().createLogger(listener.getLogger(), pluginName);
-        if (canContinue(run.getResult())) {
-            perform(run, workspace, launcher, logger);
-        }
-        else {
-            logger.log("Skipping publisher since build result is " + run.getResult());
-        }
+        perform(run, workspace, launcher, logger);
     }
 
     /**


### PR DESCRIPTION
Remove CanContinue flag, so post-build actions will perform all the
time.