### PR TITLE
[JENKINS-41753] Rendering issue with Static Code Analysis Plugin

### DIFF
--- a/src/main/resources/hudson/plugins/analysis/core/AbstractProjectAction/floatingBox.jelly
+++ b/src/main/resources/hudson/plugins/analysis/core/AbstractProjectAction/floatingBox.jelly
@@ -2,7 +2,7 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
   xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:local="local">
   <j:if test="${from.isTrendVisible(request)}">
-    <div align="right">
+    <div align="right" style="position:relative; z-index:1">
       <div class="test-trend-caption">
         ${from.trendName}
       </div>


### PR DESCRIPTION
This PR partly fixes https://issues.jenkins-ci.org/browse/JENKINS-41753

Pipeline stage view over-renders the floating box what makes the links dead. Setting the z-value is a workaround for that problem.