### PR TITLE
[JENKINS-14185] Added global configuration to disable trend graphs.

### DIFF
--- a/src/main/java/hudson/plugins/analysis/core/GlobalSettings.java
+++ b/src/main/java/hudson/plugins/analysis/core/GlobalSettings.java
@@ -29,7 +29,12 @@ public class GlobalSettings extends RunListener<Run<?, ?>> implements Describabl
     }
 
     private static DescriptorImpl findDescriptor() {
-        return (DescriptorImpl)Jenkins.getInstance().getDescriptorOrDie(GlobalSettings.class);
+        Jenkins jenkinsInstance = Jenkins.getInstance();
+        if (jenkinsInstance == null) {
+            /* Throw AssertionError exception to match behavior of Jenkins.getDescriptorOrDie */
+            throw new AssertionError("No Jenkins instance");
+        }
+        return (DescriptorImpl) jenkinsInstance.getDescriptorOrDie(GlobalSettings.class);
     }
 
     /**
@@ -50,6 +55,7 @@ public class GlobalSettings extends RunListener<Run<?, ?>> implements Describabl
     public static class DescriptorImpl extends Descriptor<GlobalSettings> implements Settings {
         private Boolean isQuiet;
         private Boolean failOnCorrupt;
+        private Boolean emptyGraphByDefault;
 
         private final CopyOnWriteList<AnalysisConfiguration> configurations = new CopyOnWriteList<AnalysisConfiguration>();
 
@@ -155,6 +161,21 @@ public class GlobalSettings extends RunListener<Run<?, ?>> implements Describabl
          */
         public void setFailOnCorrupt(final Boolean value) {
             failOnCorrupt = value;
+        }
+
+        @Override
+        public Boolean getEmptyGraphByDefault() {
+            return getValidBoolean(emptyGraphByDefault);
+        }
+
+        /**
+         * Sets the value of the emptyGraphByDefault boolean property.
+         *
+         * @param value
+         *            the value to set
+         */
+        public void setEmptyGraphByDefault(final Boolean value) {
+            emptyGraphByDefault = value;
         }
 
         private Boolean getValidBoolean(final Boolean value) {

--- a/src/main/java/hudson/plugins/analysis/core/SerializableSettings.java
+++ b/src/main/java/hudson/plugins/analysis/core/SerializableSettings.java
@@ -11,6 +11,7 @@ public class SerializableSettings implements Settings, Serializable {
     private static final long serialVersionUID = 2078877884081589761L;
 
     private final boolean failOnCorrupt;
+    private final boolean emptyGraphByDefault;
     private final boolean quietMode;
     private final AnalysisConfiguration[] configurations;
 
@@ -23,6 +24,7 @@ public class SerializableSettings implements Settings, Serializable {
     public SerializableSettings(final Settings original) {
         failOnCorrupt = original.getFailOnCorrupt();
         quietMode = original.getQuietMode();
+        emptyGraphByDefault = original.getEmptyGraphByDefault();
         configurations = copy(original.getConfigurations());
     }
 
@@ -40,6 +42,11 @@ public class SerializableSettings implements Settings, Serializable {
     @Override
     public Boolean getFailOnCorrupt() {
         return failOnCorrupt;
+    }
+
+    @Override
+    public Boolean getEmptyGraphByDefault() {
+        return emptyGraphByDefault;
     }
 
     @Override

--- a/src/main/java/hudson/plugins/analysis/core/Settings.java
+++ b/src/main/java/hudson/plugins/analysis/core/Settings.java
@@ -22,6 +22,13 @@ public interface Settings {
     Boolean getFailOnCorrupt();
 
     /**
+     * Returns whether the trend graph should be empty by default.
+     *
+     * @return on <code>true</code> the trend graph will be empty by default, on <code>false</code> the default trend graph will be shown.
+     */
+    Boolean getEmptyGraphByDefault();
+
+    /**
      * Returns the defined analysis configurations.
      *
      * @return the configurations

--- a/src/main/java/hudson/plugins/analysis/graph/GraphConfiguration.java
+++ b/src/main/java/hudson/plugins/analysis/graph/GraphConfiguration.java
@@ -21,6 +21,8 @@ import hudson.model.AbstractProject;
 
 import hudson.util.FormValidation;
 
+import hudson.plugins.analysis.core.GlobalSettings;
+
 /**
  * Configuration properties of a trend graph.
  */
@@ -33,6 +35,7 @@ public class GraphConfiguration  {
     private static final int DEFAULT_DAY_COUNT = 30;
     private static final int DEFAULT_WIDTH = 500;
     private static final int DEFAULT_HEIGHT = 200;
+    private static final BuildResultGraph EMPTY_GRAPH = new EmptyGraph();
     private static final BuildResultGraph DEFAULT_GRAPH = new PriorityGraph();
 
     /** Separator of cookie values. */
@@ -431,8 +434,21 @@ public class GraphConfiguration  {
         width  = DEFAULT_WIDTH;
         buildCount = DEFAULT_BUILD_COUNT;
         dayCount = DEFAULT_DAY_COUNT;
-        graphType = DEFAULT_GRAPH;
+
+        graphType = graphTypeBySettings();
+
         useBuildDate = DEFAULT_USE_BUILD_DATE;
+    }
+
+    private BuildResultGraph graphTypeBySettings() {
+        try {
+	        if(GlobalSettings.instance().getEmptyGraphByDefault()) {
+	            return EMPTY_GRAPH;
+	        }
+	    } catch (AssertionError exception) {
+	        // ignore
+        }
+        return DEFAULT_GRAPH;
     }
 
     /**

--- a/src/main/resources/hudson/plugins/analysis/core/GlobalSettings/global.jelly
+++ b/src/main/resources/hudson/plugins/analysis/core/GlobalSettings/global.jelly
@@ -10,6 +10,10 @@
       <f:checkbox />
     </f:entry>
 
+    <f:entry field="emptyGraphByDefault" title="${%emptyGraphByDefault.title}" description="${%emptyGraphByDefault.description}">
+      <f:checkbox />
+    </f:entry>
+
     <f:entry title="${%configurations.title}" description="${%configurations.description}">
       <f:repeatableProperty field="configurations"/>
     </f:entry>

--- a/src/main/resources/hudson/plugins/analysis/core/GlobalSettings/global.properties
+++ b/src/main/resources/hudson/plugins/analysis/core/GlobalSettings/global.properties
@@ -6,6 +6,9 @@ quietMode.description=If checked then no logging statements will be reported in 
 failOnCorrupt.title=Fail On Corrupt Files
 failOnCorrupt.description=If checked then parsing errors (due to corrupt input files, etc.) will fail a build. Otherwise the error is shown in the plug-in results view.
 
+emptyGraphByDefault.title=Disable Trend Graphs by default
+emptyGraphByDefault.description=If checked then the trend graphs will be empty by default.
+
 configurations.title=Threshold Configurations
 configurations.description=Define global threshold configurations for the static code analysis plug-ins. These configurations \
     can be shared across different jobs and different plug-ins.

--- a/src/main/resources/hudson/plugins/analysis/core/GlobalSettings/global_de.properties
+++ b/src/main/resources/hudson/plugins/analysis/core/GlobalSettings/global_de.properties
@@ -7,6 +7,9 @@ failOnCorrupt.title=Fehlschlag bei fehlerhaften Dateien
 failOnCorrupt.description=Falls aktiviert, wird der Build als fehlgeschlagen markiert, sobald eine zu parsende Datei \
     nicht eingelesen werden kann (z.B. weil die Datei fehlerhaft ist). Andernfalls werden Fehler auf der Seite mit den Plug-in Ergebnissen dargestellt.
 
+emptyGraphByDefault.title=Trend Graphen standardmäßig deaktivieren
+emptyGraphByDefault.description=Falls aktiviert, wird der Trend Graph standardmäßig nicht angezeigt.
+
 configurations.title=Grenzwertekonfigurationen
 configurations.description=Hier können globale Grenzwertkonfigurationen definiert werden, die in allen Projekten referenziert werden können, \
   die statische Codeanalyse Plug-ins in verwenden.

--- a/src/test/java/hudson/plugins/analysis/core/GlobalSettingsTest.java
+++ b/src/test/java/hudson/plugins/analysis/core/GlobalSettingsTest.java
@@ -59,7 +59,7 @@ public class GlobalSettingsTest {
      */
     @Test
     public void verifyJsonConversionTwoConfigurationElements() {
-        String input = "{\"quietMode\":true,\"failOnCorrupt\":false,\"configurations\":["
+        String input = "{\"quietMode\":true,\"failOnCorrupt\":false,\"emptyGraphByDefault\":true,\"configurations\":["
                 + "{\"name\":\"Eins\",\"canRunOnFailed\":false,\"defaultEncoding\":\"\",\"shouldDetectModules\":false,\"healthy\":\"\",\"unHealthy\":\"\",\"thresholdLimit\":\"low\",\"unstableTotalAll\":\"\",\"unstableTotalHigh\":\"\",\"unstableTotalNormal\":\"\",\"unstableTotalLow\":\"\",\"failedTotalAll\":\"\",\"failedTotalHigh\":\"\",\"failedTotalNormal\":\"\",\"failedTotalLow\":\"\"},"
                 + "{\"name\":\"Zwei\",\"canRunOnFailed\":false,\"defaultEncoding\":\"\",\"shouldDetectModules\":false,\"healthy\":\"\",\"unHealthy\":\"\",\"thresholdLimit\":\"low\",\"unstableTotalAll\":\"\",\"unstableTotalHigh\":\"\",\"unstableTotalNormal\":\"\",\"unstableTotalLow\":\"\",\"failedTotalAll\":\"\",\"failedTotalHigh\":\"\",\"failedTotalNormal\":\"\",\"failedTotalLow\":\"\",\"canComputeNew\":{\"unstableNewAll\":\"\",\"unstableNewHigh\":\"\",\"unstableNewNormal\":\"\",\"unstableNewLow\":\"\",\"failedNewAll\":\"\",\"failedNewHigh\":\"\",\"failedNewNormal\":\"\",\"failedNewLow\":\"\",\"useDeltaValues\":false,\"useStableBuildAsReference\":false}}]}}";
         DescriptorImpl settings = convert(input);
@@ -71,6 +71,7 @@ public class GlobalSettingsTest {
         assertEquals("Wrong name of configuration", "Zwei", configurations[1].getName());
 
         verifyBooleans(settings, true, false);
+        assertEquals("Wrong empty graph mode", true, settings.getEmptyGraphByDefault());
     }
 
     private void verifyBooleans(final DescriptorImpl settings, final boolean expectedQuiet, final boolean expectedCorrupt) {


### PR DESCRIPTION
Because the Trend Graphs sometimes move the Pipeline Stage View to the bottom of the page there was the requirement to disable them by default and any user who likes to can activate the Trend Graphs for their view.

Local manually tested with warnings-plugin: 4.43