### PR TITLE
Fixed Request Path for Windows OS

### DIFF
--- a/src/main/java/hudson/plugins/analysis/util/AbstractBlamer.java
+++ b/src/main/java/hudson/plugins/analysis/util/AbstractBlamer.java
@@ -5,7 +5,6 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import org.apache.commons.lang3.StringUtils;
 
 import org.apache.commons.lang3.exception.ExceptionUtils;
 
@@ -132,15 +131,12 @@ public abstract class AbstractBlamer implements Blamer {
     }
 
     private String getWorkspacePath() {
-        return getCanonicalPath(workspace.getRemote().replace('\\', '/'));
+        return getCanonicalPath(workspace.getRemote());
     }
 
     private String getCanonicalPath(final String path) {
         try {
-            String filePath;
-            filePath = new File(path).getCanonicalPath();
-            filePath = StringUtils.strip(filePath).replace('\\', '/');
-            return filePath;
+            return new File(path).getCanonicalPath().replace('\\', '/');
         }
         catch (IOException e) {
             return path;

--- a/src/main/java/hudson/plugins/analysis/util/AbstractBlamer.java
+++ b/src/main/java/hudson/plugins/analysis/util/AbstractBlamer.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import org.apache.commons.lang3.StringUtils;
 
 import org.apache.commons.lang3.exception.ExceptionUtils;
 
@@ -136,7 +137,10 @@ public abstract class AbstractBlamer implements Blamer {
 
     private String getCanonicalPath(final String path) {
         try {
-            return new File(path).getCanonicalPath();
+            String filePath;
+            filePath = new File(path).getCanonicalPath();
+            filePath = StringUtils.strip(filePath).replace('\\', '/');
+            return filePath;
         }
         catch (IOException e) {
             return path;

--- a/src/main/java/hudson/plugins/analysis/util/BlameRequest.java
+++ b/src/main/java/hudson/plugins/analysis/util/BlameRequest.java
@@ -20,7 +20,13 @@ public class BlameRequest implements Iterable<Integer>, Serializable {
     private final Map<Integer, String> emailByLine = new HashMap<Integer, String>();
 
     public BlameRequest(final String fileName, final int lineNumber) {
-        this.fileName = fileName;
+        String OS = System.getProperty("os.name");
+        if (OS.startsWith("Windows")) {
+            this.fileName = fileName.replaceAll("\\\\", "/");
+        } 
+        else {
+            this.fileName = fileName;            
+        }        
         addLineNumber(lineNumber);
     }
 

--- a/src/main/java/hudson/plugins/analysis/util/BlameRequest.java
+++ b/src/main/java/hudson/plugins/analysis/util/BlameRequest.java
@@ -20,13 +20,7 @@ public class BlameRequest implements Iterable<Integer>, Serializable {
     private final Map<Integer, String> emailByLine = new HashMap<Integer, String>();
 
     public BlameRequest(final String fileName, final int lineNumber) {
-        String OS = System.getProperty("os.name");
-        if (OS.startsWith("Windows")) {
-            this.fileName = fileName.replaceAll("\\\\", "/");
-        } 
-        else {
-            this.fileName = fileName;            
-        }        
+        this.fileName = fileName;
         addLineNumber(lineNumber);
     }
 


### PR DESCRIPTION
First a huge thanks for making terrific plugins for Jenkins, you are helping my team a lot :)

## What this change does
I changed the way `BlameRequest.fileName` is set in case it received a filename with a path containing `\` due to Jenkins running on Windows.  In case a Windows OS is detected, it will find an replace all `\` by `/` so JGit can handle the BlameRequest.

## Context
- Jenkins with Analysis Core+DRY plugins installed running on Windows Server
- DRY input: xml file generated by Simian
- Noticed code duplicate author info was not displayed on  Duplicate Code Origin tab and when I checked the console output I saw the following:
``` 
<Git Blamer> No blame results for request <aaaa\bbbb.cpp - [258, 2307, 2563, 260]>
```
- After a bit of trial and error(tried editing file path in the simian xml files, didn't work) I concluded JGit API couldn't handle path with backslashes, which led me to change how `BlameRequest.filename` is set in analysis-core and it worked! :)

---
This is my first pull request on github.com (I mainly use github enterprise...) and I haven't coded in Java almost 10 years, so any advice would be greatly appreciated and please let me know if you have any questions,

Matthieu Parizy