### PR TITLE
WIP: Ability to specify reference build from another job

### DIFF
--- a/src/main/java/hudson/plugins/analysis/core/BuildHistory.java
+++ b/src/main/java/hudson/plugins/analysis/core/BuildHistory.java
@@ -134,7 +134,7 @@ public class BuildHistory {
     }
 
     private ResultAction<? extends BuildResult> getAction(final boolean isStatusRelevant, final boolean mustBeStable) {
-        for (Run<?, ?> build = baseline.getPreviousBuild(); build != null; build = build.getPreviousBuild()) {
+        for (Run<?, ?> build = baseline; build != null; build = build.getPreviousBuild()) { // FIXME: should still initialize with build = baseline.getPreviousBuild() in some cases
             ResultAction<? extends BuildResult> action = getResultAction(build);
             if (hasValidResult(build, mustBeStable, action) && isSuccessfulAction(action, isStatusRelevant)) {
                 return action;

--- a/src/main/java/hudson/plugins/analysis/core/HealthAwarePublisher.java
+++ b/src/main/java/hudson/plugins/analysis/core/HealthAwarePublisher.java
@@ -75,7 +75,7 @@ public abstract class HealthAwarePublisher extends HealthAwareRecorder {
             }
 
             if (referenceBuild != null) {
-                logger.log("Computing warning deltas based on reference build " + referenceBuild.getDisplayName());
+                logger.log("Computing warning deltas based on reference build " + referenceBuild.getFullDisplayName());
             }
         }
         catch (InterruptedException exception) {

--- a/src/main/java/hudson/plugins/analysis/core/HealthAwareRecorder.java
+++ b/src/main/java/hudson/plugins/analysis/core/HealthAwareRecorder.java
@@ -33,7 +33,7 @@ import hudson.plugins.analysis.util.LoggerFactory;
 import hudson.plugins.analysis.util.PluginLogger;
 import hudson.plugins.analysis.util.model.FileAnnotation;
 import hudson.plugins.analysis.util.model.Priority;
-import hudson.remoting.VirtualChannel;§
+import hudson.remoting.VirtualChannel;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Builder;
 import hudson.tasks.Maven;

--- a/src/test/java/hudson/plugins/analysis/core/HealthAwareRecorderTest.java
+++ b/src/test/java/hudson/plugins/analysis/core/HealthAwareRecorderTest.java
@@ -1,0 +1,106 @@
+package hudson.plugins.analysis.core;
+
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.matrix.MatrixAggregator;
+import hudson.matrix.MatrixBuild;
+import hudson.model.BuildListener;
+import hudson.model.Job;
+import hudson.model.Run;
+import hudson.plugins.analysis.util.PluginLogger;
+import jenkins.model.Jenkins;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class HealthAwareRecorderTest {
+
+    final private StubbedHealthAwareRecorder recorder = new StubbedHealthAwareRecorder("");
+    final private Job currentJob = mock(Job.class);
+    final private Run currentBuild = mock(Run.class);
+    final private Jenkins jenkins = mock(Jenkins.class);
+
+    @Before
+    public void setUp() {
+        when(currentBuild.getParent()).thenReturn(currentJob);
+    }
+
+    @Test
+    public void shouldUseLastBuildOfResolvedJobWhenOnlyJobNameIsProvided() throws Exception {
+        final String jobName = "SomeFolder/SomeJob";
+        final Job selectedJob = mock(Job.class);
+        final Run lastBuild = mock(Run.class);
+        when(selectedJob.getLastBuild()).thenReturn(lastBuild);
+        when(jenkins.getItemByFullName(jobName)).thenReturn(selectedJob);
+
+        recorder.setReferenceJobName(jobName);
+        final Run referenceBuild = recorder.resolveReferenceBuild(currentBuild, jenkins);
+
+        assertEquals(lastBuild, referenceBuild);
+    }
+
+    @Test
+    public void shouldResolveBuildOfCurrentJobIfOnlyBuildNumberIsProvided() throws Exception {
+        final String buildNumber = "999";
+        final Run selectedBuild = mock(Run.class);
+        when(currentJob.getBuildByNumber(Integer.valueOf(buildNumber))).thenReturn(selectedBuild);
+
+        recorder.setReferenceBuildNumber(buildNumber);
+        final Run referenceBuild = recorder.resolveReferenceBuild(currentBuild, jenkins);
+
+        assertEquals(selectedBuild, referenceBuild);
+    }
+
+    @Test
+    public void shouldResolveSpecificBuildOfSpecificJobWhenBothOptionsProvided() throws Exception {
+        final String jobName = "SomeFolder/SomeJob";
+        final String buildNumber = "999";
+        final Run specificBuild = mock(Run.class);
+        final Job specificJob = mock(Job.class);
+        when(specificJob.getBuildByNumber(Integer.valueOf(buildNumber))).thenReturn(specificBuild);
+        when(jenkins.getItemByFullName(jobName)).thenReturn(specificJob);
+
+        recorder.setReferenceBuildNumber(buildNumber);
+        recorder.setReferenceJobName(jobName);
+        final Run referenceBuild = recorder.resolveReferenceBuild(currentBuild, jenkins);
+
+        assertEquals(specificBuild, referenceBuild);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowWhenProvidedJobNameCantBeResolved() {
+        recorder.setReferenceJobName("NonExistingJobName");
+        recorder.resolveReferenceBuild(currentBuild, jenkins);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowWhenProvidedBuildNumberCantBeResolved() {
+        recorder.setReferenceBuildNumber("InvalidNumber");
+        recorder.resolveReferenceBuild(currentBuild, jenkins);
+    }
+
+    static class StubbedHealthAwareRecorder extends HealthAwareRecorder {
+        StubbedHealthAwareRecorder(String pluginName) {
+            super(pluginName);
+        }
+
+        public Run resolveReferenceBuild(Run currentBuild, Jenkins jenkins) {
+            return getReferenceBuild(currentBuild, jenkins);
+        }
+
+        @Override
+        protected boolean perform(Run<?, ?> run, FilePath workspace, Launcher launcher, PluginLogger logger) throws InterruptedException, IOException {
+            return false;
+        }
+
+        @Override
+        public MatrixAggregator createAggregator(MatrixBuild matrixBuild, Launcher launcher, BuildListener buildListener) {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
This is a proposal for implementing one of the common use cases that are currently missing. What I'd like to discuss:
* Maybe there's a better way to achieve my use case?
* Maybe this logic belongs to a different class/file?
* Maybe some further refactoring is needed?

What's implemented here - I've tested myself - works great. Will also require some minor modifications to the different plugins, [see below](#Example-PMD).

# WIP: Work in progress
* [ ] Complete javadoc 
* [ ] Fix the `(Reference build: #xx)` link so it points to the right job, if it's not the same one

# Use case
I have 2 jobs: 
1. `MyProject/Develop` - builds every commit/merge to `develop` branch
2. `MyProject/Branch` - builds every commit for pull/merge-request (MR) branches

## Desired outcome
For a reference build, builds of `MyProject/Branch` should take a build from `MyProject/Develop`, one which they branched-off from, so that issue/warning delta calculation is correct and we could reliably use `(unstable|failed)New*` deltas

## Obstacle
There was no way of using reference build from another job

# What's done
Added 2 new data-bound setters:
- referenceJobName
- referenceBuildNumber

## Example
```groovy
// Find a hash for the most recent common ancestor between current MR branch and branch 'develop'
// This is the commit we need to compare to
def commitHash = sh(
    script: "git merge-base develop ${GIT_BRANCH}",
    returnStdout: true
).trim()

// Pseudo-code: find Jenkins build for a given git commit SHA hash
def refBuildNumber = getBuildNumberForCommitHash('MyProject/Develop', commitHash)

pmd canComputeNew: true,
        canRunOnFailed: true,
        defaultEncoding: '',
        pattern: 'build/results/pmd.xml',
        failedNewAll: '0',
        referenceJobName: 'MyProject/Develop', // Take reference build from this job
        referenceBuildNumber: String.valueOf(refBuildNumber) // Take reference build with this specific number
```

# Modifications to plugins
## Example - PMD
`hudson/plugins/pmd/PmdPublisher.java`:
```java
    @Override
    public BuildResult perform(final Run<?, ?> build, final FilePath workspace, final PluginLogger logger) throws InterruptedException, IOException {
        // ...
        blame(project.getAnnotations(), build, workspace);

// BEFORE:
        PmdResult result = new PmdResult(build, getDefaultEncoding(), project, usePreviousBuildAsReference(), useOnlyStableBuildsAsReference());

// MODIFIED, start ---->
        // Use the new ' protected getReferenceBuildOrNull' method from 
        Run referenceBuild = getReferenceBuildOrNull(build, Jenkins.getInstance());
        if (referenceBuild == null) {
            referenceBuild = build;
        }

        BuildHistory history = new BuildHistory(referenceBuild, PmdResultAction.class, usePreviousBuildAsReference(), useOnlyStableBuildsAsReference());

        // Use a different constructor to pass in custom BuildHistory
        PmdResult result = new PmdResult(build, history, project, getDefaultEncoding(), true);
// <---- MODIFIED, end
        build.addAction(new PmdResultAction(build, this, result));
        return result;
    }
```

# Related issues
https://issues.jenkins-ci.org/browse/JENKINS-13056