### PR TITLE
Using /bin/bash instead of /bin/sh to fix problems on linux hosts

### DIFF
--- a/clean.sh
+++ b/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if [[ -z "$JENKINS_HOME" ]]; then
     echo "JENKINS_HOME is not defined" 1>&2

--- a/go.sh
+++ b/go.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if [[ -z "$JENKINS_HOME" ]]; then
     echo "JENKINS_HOME is not defined" 1>&2

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,4 +1,4 @@
-#!/bin/sh 
+#!/bin/bash
 
 if [[ -z "$JENKINS_HOME" ]]; then
     echo "JENKINS_HOME is not defined" 1>&2

--- a/skip.sh
+++ b/skip.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if [[ -z "$JENKINS_HOME" ]]; then
     echo "JENKINS_HOME is not defined" 1>&2


### PR DESCRIPTION
Many Linux are using a default shell, which does'nt support the used syntax for the if-statements thus the bash should be explicitly used.