### PR TITLE
Fix for excluding column ordering of tables from localStorage

### DIFF
--- a/src/main/resources/issues/list.jelly
+++ b/src/main/resources/issues/list.jelly
@@ -12,7 +12,7 @@
 
   <div role="tabpanel" id="warningsDetails" class="tab-pane fade">
     <j:forEach var="i" items="${issues}">
-      <table class="table table-hover table-striped" id="details">
+      <table class="table table-hover table-striped ignore-column-sorting">
         <thead>
           <tr>
             <th>

--- a/src/main/webapp/js/issues-detail.js
+++ b/src/main/webapp/js/issues-detail.js
@@ -178,7 +178,7 @@
     /**
      * Stores the order of every table in the local storage of the browser.
      */
-    var tables = $('#statistics').find('table').not('#details');
+    var tables = $('#statistics').find('table').not('.ignore-column-sorting');
     tables.on('order.dt', function (e) {
         var table = $(e.target);
         var order = table.DataTable().order();

--- a/src/main/webapp/js/issues-detail.js
+++ b/src/main/webapp/js/issues-detail.js
@@ -141,17 +141,11 @@
     });
 
     /**
-     * Activate the tab that has been visited the last time. If there is no such tab, highlight the first one.
+     * Issues are loaded on demand: if the active tab shows the issues table, then the content is loaded using an Ajax call.
      */
-    var detailsTabs = $('#tab-details');
-    detailsTabs.find('li:first-child a').tab('show');
-    $('a[data-toggle="tab"]').on('show.bs.tab', function (e) {
+    var tabToggleLink = $('a[data-toggle="tab"]');
+    tabToggleLink.on('show.bs.tab', function (e) {
         var activeTab = $(e.target).attr('href');
-        localStorage.setItem('activeTab', activeTab);
-
-        /**
-         * If the active tab contains the issues, then load the content using an Ajax call.
-         */
         if (activeTab === '#issuesContent' && table.data().length === 0 ) {
             view.getTableModel(function (t) {
                 (function ($) {
@@ -160,6 +154,20 @@
                 })(jQuery);
             });
         }
+    });
+
+    /**
+     * Activate the tab that has been visited the last time. If there is no such tab, highlight the first one.
+     */
+    var detailsTabs = $('#tab-details');
+    detailsTabs.find('li:first-child a').tab('show');
+
+    /**
+     * Store the selected tab in Browser's local storage.
+     */
+    tabToggleLink.on('show.bs.tab', function (e) {
+        var activeTab = $(e.target).attr('href');
+        localStorage.setItem('activeTab', activeTab);
     });
 
     var activeTab = localStorage.getItem('activeTab');


### PR DESCRIPTION
- changed redundant usage of id="details" to use the class "ignore-column-sorting".
- This will fix the problem, that the details-id was used multiple times within the same html-page.